### PR TITLE
feat(setup): captive-portal probe log carries the response side

### DIFF
--- a/src/setup_server.py
+++ b/src/setup_server.py
@@ -956,24 +956,38 @@ class SetupHandler(http.server.BaseHTTPRequestHandler):
         # probed (is it one we recognize?), which UA/iOS version, and what we
         # returned. Pair this with dnsmasq's log-queries (already enabled) to
         # see the full DNS→HTTP probe path a phone takes on join.
-        if PROVISIONING_MODE:
-            ua = self.headers.get("User-Agent", "")
-            print(f"CAPTIVE-PROBE: host={host!r} path={path!r} ua={ua[:80]!r}", flush=True)
+        # The RESPONSE side (branch + status + bytes) is logged too: the
+        # litclock-dev#526 repro established that receipt-only logging cannot
+        # distinguish "sheet never opened" from "sheet opened and died" —
+        # and the 80-char UA truncation cut off exactly before the Safari/
+        # token that separates a manual browser open from the CNA WebView.
+        def _probe_log(branch, status, nbytes):
+            if PROVISIONING_MODE:
+                ua = self.headers.get("User-Agent", "")
+                print(
+                    f"CAPTIVE-PROBE: host={host!r} path={path!r} -> {branch} "
+                    f"status={status} bytes={nbytes} ua={ua[:200]!r}",
+                    flush=True,
+                )
 
         # iOS probes — return a tiny JS-free bridge page. A non-"Success" 200
         # opens the CNA sheet; keeping the response small (~1 KB, no JS) is
         # what makes iOS actually pop the sheet instead of burying it in
         # Control Center. The bridge links into the real setup form.
         if path in ("/hotspot-detect.html", "/library/test/success.html"):
-            self.send_html(_build_cna_bridge_html())
+            body = _build_cna_bridge_html()
+            self.send_html(body)
+            _probe_log("cna-bridge", 200, len(body.encode()))
             return True
         # Android probes — 302 redirect triggers "Sign in to network"
         if path in ("/generate_204", "/gen_204"):
             self._redirect_to_setup()
+            _probe_log("redirect-setup", 302, 0)
             return True
         # Windows/Firefox probes — 302 redirect
         if path in ("/connecttest.txt", "/ncsi.txt", "/canonical.html", "/success.txt"):
             self._redirect_to_setup()
+            _probe_log("redirect-setup", 302, 0)
             return True
         # Host-based fallback for probes that hit an unexpected path (e.g.
         # some iOS versions probe captive.apple.com/ with path "/"). Only
@@ -983,10 +997,14 @@ class SetupHandler(http.server.BaseHTTPRequestHandler):
         host_clean = host.split(":")[0].lower()
         if host_clean in CAPTIVE_PORTAL_HOSTS:
             if host_clean in APPLE_CAPTIVE_PORTAL_HOSTS:
-                self.send_html(_build_cna_bridge_html())
+                body = _build_cna_bridge_html()
+                self.send_html(body)
+                _probe_log("cna-bridge-hostmatch", 200, len(body.encode()))
             else:
                 self._redirect_to_setup()
+                _probe_log("redirect-setup-hostmatch", 302, 0)
             return True
+        _probe_log("no-match-fallthrough", 0, 0)
         return False
 
     def do_GET(self):

--- a/tests/test_setup_server.py
+++ b/tests/test_setup_server.py
@@ -1259,6 +1259,22 @@ class TestCaptivePortalProbeRouting:
         assert "/hotspot-detect.html" in out
         assert "CaptiveNetworkSupport" in out
 
+    def test_probe_log_includes_response_branch_status_bytes(self, capsys, monkeypatch):
+        """litclock-dev#526: receipt-only logging couldn't distinguish "sheet
+        never opened" from "sheet opened and died". The log line must carry
+        the response side (branch, status, byte count) and enough UA (200
+        chars) to tell the CNA WebView from a manual Safari open."""
+        monkeypatch.setattr(setup_server, "PROVISIONING_MODE", True)
+        handler = _make_handler()
+        handler.send_html = __import__("unittest.mock", fromlist=["MagicMock"]).MagicMock()
+        handler.headers = {"User-Agent": "x" * 190}
+        handler._handle_captive_portal_probe("/hotspot-detect.html", "captive.apple.com")
+        out = capsys.readouterr().out
+        assert "-> cna-bridge" in out
+        assert "status=200" in out
+        assert "bytes=" in out and "bytes=0" not in out
+        assert "x" * 150 in out  # UA no longer truncated at 80 chars
+
     def test_probe_diagnostic_silent_outside_provisioning(self, capsys, monkeypatch):
         """The diagnostic is provisioning-only — normal-mode HTTPS setup must
         not spam stdout (and must not touch self.headers when not logging)."""


### PR DESCRIPTION
Instrumentation for the captive-portal auto-open investigation: the QA repro (2× runs, SSID forgotten each time, serving code byte-identical to the last validated version) stalled because receipt-only logging can't distinguish "CNA sheet never opened" from "sheet opened and died", and the 80-char UA truncation cut off exactly before the `Safari/` token that separates a manual browser open from the CNA WebView.

Each CAPTIVE-PROBE line now logs `-> branch status=NNN bytes=NNN` (cna-bridge / redirect-setup / hostmatch variants / no-match-fallthrough) with a 200-char UA. Provisioning-gated as before; the headers-untouched-outside-provisioning contract is preserved (UA read moved inside the guard) and pinned by the existing silent-mode test. +1 test.