### PR TITLE
docs(readme): reorganize around the builder's journey

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 ![LitClock on a shelf, showing a passage from Confess, Fletch at twenty-six minutes past ten](docs/media/litclock-photo.jpg)
 
-LitClock is built for people who want a literary clock on their wall and never want to think about it again: setup is a two-minute, phone-only affair, and after that the clock configures, updates, and heals itself. **The defaults are the product.**
+LitClock is built for people who want a literary clock on their shelf and never want to think about it again: setup is a two-minute, phone-only affair, and after that the clock configures, updates, and heals itself. **The defaults are the product.**
 
 **[Build one](#build-one)** · **[Living with it](#living-with-it)** · **[Give one away](#give-one-away)** · **[Under the hood](#under-the-hood)** · **[Credits](#credits)**
 

--- a/README.md
+++ b/README.md
@@ -13,62 +13,71 @@
   <a href="https://www.raspberrypi.com/"><img src="https://img.shields.io/badge/platform-Raspberry%20Pi-c51a4a.svg" alt="Platform"></a>
 </p>
 
-<p align="center">A Raspberry Pi Zero 2 W with a Waveshare 7.5" e-Paper display (800x480) that shows the time using 4,800+ curated literary quotes, one for every minute of the day, along with the date and weather.</p>
+<p align="center">A clock that tells the time with literature: 4,800+ curated book passages, one for every minute of the day, on a paper-like e-ink display — with the date and weather.</p>
 
 ![LitClock on a shelf, showing a passage from Confess, Fletch at twenty-six minutes past ten](docs/media/litclock-photo.jpg)
+
+LitClock is built for people who want a literary clock on their wall and never want to think about it again: setup is a two-minute, phone-only affair, and after that the clock configures, updates, and heals itself. **The defaults are the product.**
+
+**[Build one](#build-one)** · **[Living with it](#living-with-it)** · **[Give one away](#give-one-away)** · **[Under the hood](#under-the-hood)** · **[Credits](#credits)**
 
 ### One-minute tour
 
 ![A one-minute tour of LitClock: the literary clock face, the two-minute WiFi-only setup, and the phone control app](docs/media/litclock-intro.gif)
 
-## Philosophy
+## Build one
 
-LitClock is built for people who want a literary clock on their wall and never want to think about it again. It is not an SSH-optional developer tool. If you are a non-technical user, you should not need to do anything after first boot: setup is a one-time "join the hotspot, pick your WiFi" step, and everything else — location, timezone, temperature units — configures itself. If you are a technically comfortable user, you can enable SSH (it ships off — see [Recovering a LitClock](docs/recovery.md)) and disable or customize any of this. **The defaults are the product.**
+Four steps, roughly an afternoon (most of it waiting for the 3D printer).
 
-That's why the clock updates its own software quietly on a weekly schedule (see [Updating](#updating)), and why day-to-day control happens from a phone — a small web app served by the clock itself — rather than a terminal.
+### 1. Get the parts
 
-## Credits
+| Part | Notes | ~Cost |
+|------|-------|-------|
+| [Raspberry Pi Zero 2 W](https://www.raspberrypi.com/products/raspberry-pi-zero-2-w/) | Get the **WH** variant (pre-soldered header) unless you like soldering | $15 |
+| [Waveshare 7.5" e-Paper HAT (V2)](https://www.amazon.com/dp/B075R4QY3L) | 800×480, black/white ([product page](https://www.waveshare.com/7.5inch-e-paper-hat.htm)) | $60 |
+| microSDHC card | 32 GB recommended | $10 |
+| Micro-USB power supply | 5V/2A minimum | $10 |
+| 3D-printed case *(optional)* | PLA — see step 3 | $5–30 |
+| M2.5 threaded inserts + screws, USB-C→Micro-USB adapter *(case only)* | Inserts secure the case; the adapter puts a clean USB-C port on the back | $8 |
 
-This project was originally forked from [jadonn/literary-clock](https://github.com/jadonn/literary-clock) and has since been extensively rewritten. The literary clock concept originates from [Jaap Meijers's Instructables project](https://www.instructables.com/Literary-Clock-Made-From-E-reader/) (2018).
+Full details in **[Hardware Assembly](docs/hardware-assembly.md)**.
 
-**Code & display inspiration:**
-- [Jake Krajewski's Raspberry Pi + e-Paper Tutorial](https://medium.com/swlh/create-an-e-paper-display-for-your-raspberry-pi-with-python-2b0de7c8820c)
-- [Mendhak's Waveshare e-Paper Display](https://github.com/mendhak/waveshare-epaper-display) (MIT)
-
-**Quote database sources:**
-- [JohannesNE/literature-clock](https://github.com/JohannesNE/literature-clock) (CC BY-NC-SA 2.5)
-- [cdmoro/literature-clock](https://github.com/cdmoro/literature-clock) (MIT)
-- [The Guardian "Books blog" reader thread](https://www.theguardian.com/books/booksblog/2011/apr/21/literary-clock) — community-sourced time-referential quotes from the 2011–2018 reader comments
-
-**Case design:**
-- [Arthur Gassner's Time Teller](https://github.com/arthurgassner/timeteller) (CC BY) — the 3D-printed case; lightly modified STLs ship in [`3d-models/`](3d-models/) (see [Hardware Assembly](docs/hardware-assembly.md))
-
-**Assets:**
-- [Dhole's Monochrome Weather Icons](https://github.com/Dhole/weather-pixel-icons) (CC BY-SA 4.0)
-- [Google Fonts](https://fonts.google.com) — Literata (OFL 1.1)
-
-See [NOTICE.md](NOTICE.md) for full license details on third-party components.
-
-> LitClock was developed privately before this repository was published, so issue/PR numbers referenced in the [CHANGELOG](CHANGELOG.md) predate the public issue tracker.
-
-## Hardware
-
-Raspberry Pi Zero 2 W + [Waveshare 7.5" e-Paper HAT (V2)](https://www.amazon.com/dp/B075R4QY3L) (800×480, SPI — [product page](https://www.waveshare.com/7.5inch-e-paper-hat.htm)). Print-ready case STLs are included in [`3d-models/`](3d-models/) (Arthur Gassner's CC BY Time Teller design, lightly modified). For the full parts list, assembly steps, and case instructions, see **[Hardware Assembly](docs/hardware-assembly.md)**.
-
-## Installation
-
-### Option 1: Download Image (Recommended)
-
-The easiest way to get started — no terminal or technical knowledge required.
+### 2. Flash the SD card
 
 1. Download the latest `.img.xz` from **[Releases](https://github.com/kapoorankush/litclock/releases/latest)**
-2. Flash it to a microSD card using [Raspberry Pi Imager](https://www.raspberrypi.com/software/) or [balenaEtcher](https://etcher.balena.io/)
-3. Insert the SD card and power on the Pi
-4. The e-ink display shows a **"LitClock-Setup"** hotspot with its password and a QR code. Join it from your phone — the setup page opens automatically (or browse to the address shown on the display).
-5. Pick your home WiFi network, enter its password, and submit. **That's the whole form** — location, timezone, and temperature units are detected automatically once the clock is online.
-6. The display shows a "Ready to read." summary with a QR code to the clock's control app. Scan it, tap **"Done — Start the Clock"** (or just wait — the clock starts on its own a couple of minutes later), and optionally add the app to your home screen.
+2. Flash it to the microSD card with [Raspberry Pi Imager](https://www.raspberrypi.com/software/) or [balenaEtcher](https://etcher.balena.io/)
 
-Here's the whole sequence — one form, everything else automatic:
+That's it — no config files to edit, no SSH to set up. Everything else happens from your phone after power-on.
+
+<details>
+<summary><b>Installing on an existing Raspberry Pi OS instead</b> (terminal required)</summary>
+
+On a fresh Raspberry Pi OS Lite install, SSH in (or connect a keyboard) and run:
+
+```bash
+curl -sSL https://raw.githubusercontent.com/kapoorankush/litclock/master/scripts/install.sh | bash
+```
+
+The installer sets up system dependencies, the BCM2835 driver, SPI, NTP sync, the Python venv, all systemd services, and downloads the quote-image set (~130 MB — needs network; the clock falls back to a time-only display if the download fails). It also detects Pi Zero W hardware and offers the [WiFi stability fixes](#wifi-stability-pi-zero-w--zero-2-w). Reboot when it finishes — from there the flow matches the flashed image.
+
+The installer and updater are for existing OS installs only; for a fresh SD card, the downloadable image above is the way.
+</details>
+
+### 3. Print and assemble the case
+
+Print-ready STLs are in [`3d-models/`](3d-models/) — three PLA parts, lightly modified from [Arthur Gassner's Time Teller](https://timeteller.arthurgassner.com) case design (CC BY). Then:
+
+1. Connect the e-Paper HAT to the Pi's 40-pin header, and the display to the HAT via the ribbon cable
+2. Assemble the case around it — threaded inserts, the USB-C adapter on the back, screws
+
+Arthur's guide covers the case assembly beautifully, and our **[Hardware Assembly](docs/hardware-assembly.md)** page has the LitClock-specific details (ribbon-cable orientation, e-ink handling notes). No case? The bare HAT sandwich works fine on a shelf while you decide.
+
+### 4. Power on — two-minute setup
+
+1. Insert the SD card and power on. Within a minute the display shows a **"LitClock-Setup"** hotspot with its password and a QR code.
+2. Join the hotspot from your phone — the setup page opens automatically (or browse to the address shown on the display).
+3. Pick your home WiFi and enter its password. **That's the whole form** — location, timezone, and temperature units auto-detect once the clock is online.
+4. The display shows "Ready to read." with a QR code to the clock's control app. Scan it, tap **"Done — Start the Clock"** (or just wait — it starts on its own), and add the app to your home screen.
 
 <table>
   <tr>
@@ -89,54 +98,13 @@ Here's the whole sequence — one form, everything else automatic:
   </tr>
 </table>
 
-Anything the auto-detection got wrong — city, units, mature-content filter — takes a few taps to fix in the app's Settings tab.
+Anything the auto-detection got wrong — city, units, mature-content filter — takes a few taps to fix in the app's Settings tab. Prefer paper instructions? Print the **[quick-start booklet](docs/manual/)** ([A4](docs/manual/litclock-manual-A4-booklet.pdf) / [US Letter](docs/manual/litclock-manual-Letter-booklet.pdf)) — a one-sheet, fold-in-half guide written for non-technical users.
 
-**Prefer paper?** Print the **[quick-start booklet](docs/manual/)** — a one-sheet, fold-in-half guide covering the same steps ([A4](docs/manual/litclock-manual-A4-booklet.pdf) / [US Letter](docs/manual/litclock-manual-Letter-booklet.pdf)). It's written for non-technical recipients and makes a nice enclosure when the clock is a gift.
+## Living with it
 
-### Option 2: DIY Installation (Terminal Required)
+### The Control App
 
-If you prefer to install on an existing Raspberry Pi OS setup:
-
-1. Flash Raspberry Pi OS Lite to your SD card
-2. SSH into the Pi (or connect keyboard/monitor)
-3. Run the installer:
-
-```bash
-curl -sSL https://raw.githubusercontent.com/kapoorankush/litclock/master/scripts/install.sh | bash
-```
-
-The installer will:
-- Install system dependencies and BCM2835 driver
-- Enable SPI interface and NTP time sync
-- Detect Pi Zero W/Zero 2 W and offer WiFi stability fixes (see below)
-- Clone the repository to `/home/pi/litclock`
-- Download the current quote-image set (~130 MB) from the pinned [GitHub Release](https://github.com/kapoorankush/litclock/releases). Requires network at install time; the clock still runs if the download fails but will fall back to a time-only display until the images are fetched.
-- Set up Python virtual environment with required packages
-- Install systemd services for the boot splash, shutdown splash, first-boot provisioning, the control app, the self-updater, and the once-per-minute clock timer
-
-After installation, reboot. The display will guide you through the same WiFi setup as Option 1.
-
-### Option 3: Pre-configured SD Card
-
-If you received a pre-configured SD card (e.g., from a friend or family member), just insert it and power on — the setup flow is the same as Option 1, step 4.
-
-To create pre-configured SD cards for others, see [Creating SD Cards for Friends & Family](docs/sd-card-cloning.md).
-
-To build your own image from source, see [Building the Image](docs/building-image.md).
-
-### WiFi Stability (Pi Zero W / Zero 2 W)
-
-The Raspberry Pi Zero W and Zero 2 W have a known WiFi stability issue with the BCM43430 chip that can cause the system to hang and become unreachable. The installer detects this hardware and offers to apply stability fixes:
-
-- **Driver parameters**: Disables roaming and problematic power features
-- **Power management**: Disables WiFi power saving
-- **Watchdog**: Automatically reboots if WiFi becomes unreachable
-
-If you experience WiFi disconnections or system hangs, re-run the installer or manually apply the fixes described in [issue #8](https://github.com/kapoorankush/litclock/issues/8).
-
-## The Control App
-
-Every LitClock serves a small web app on your home network at **`http://litclock.local`** (or the clock's IP — the QR code at the end of setup points there). Open it in any browser, or add it to your phone's home screen for one-tap access. No account, no cloud — the app is served by the clock itself and works only on your LAN.
+Every LitClock serves a small web app on your home network at **`http://litclock.local`** (or the clock's IP — the QR in the corner of every quote points there). Open it in any browser, or add it to your phone's home screen. No account, no cloud — the app is served by the clock itself and works only on your LAN.
 
 | Tab | What it does |
 |-----|--------------|
@@ -152,9 +120,9 @@ Every LitClock serves a small web app on your home network at **`http://litclock
   <img src="docs/images/pwa-system.png" alt="System tab — restart, reset WiFi, factory reset" width="260">
 </p>
 
-## Configuration
+### Configuration
 
-Weather works out of the box — no signup, no API key. The clock uses [Open-Meteo](https://open-meteo.com) as its default forecast provider, and location, timezone, and units are auto-detected from your internet connection during setup. Day-to-day changes (city, units, mature-content filter) are made in the control app's **Settings** tab. That's the whole configuration.
+Weather works out of the box — no signup, no API key. The clock uses [Open-Meteo](https://open-meteo.com) as its default forecast provider, and location, timezone, and units are auto-detected during setup. Day-to-day changes are made in the control app's **Settings** tab. That's the whole configuration.
 
 Under the hood, settings live in `/home/pi/litclock/env.sh`. You only need to touch this file on a DIY install or for the advanced options below:
 
@@ -181,9 +149,10 @@ export WEATHER_TTL=3600
 | `WEATHER_UNITS` | `imperial` (Fahrenheit) or `metric` (Celsius) |
 | `ALLOW_NSFW_QUOTES` | Show quotes with mature content (default: `false`) |
 | `WEATHER_TTL` | Weather cache duration in seconds (default: `3600`) |
-| `OPENWEATHERMAP_APIKEY` | Optional — use OpenWeatherMap instead of Open-Meteo (see "Advanced: using OpenWeatherMap" below) |
+| `OPENWEATHERMAP_APIKEY` | Optional — use OpenWeatherMap instead of Open-Meteo (see below) |
 
-### Advanced: using OpenWeatherMap instead of Open-Meteo
+<details>
+<summary><b>Advanced: using OpenWeatherMap instead of Open-Meteo</b></summary>
 
 By default the clock uses Open-Meteo, which is free and requires no signup. If you'd rather use OpenWeatherMap (for example, you already have a key or prefer its forecast model):
 
@@ -192,8 +161,10 @@ By default the clock uses Open-Meteo, which is free and requires no signup. If y
 3. Restart the timer: `sudo systemctl restart litclock.timer`.
 
 The OpenWeatherMap free tier allows 1,000 calls per day; the clock caches forecasts for an hour by default, so usage stays well within limits.
+</details>
 
-### Advanced: overriding location coordinates
+<details>
+<summary><b>Advanced: overriding location coordinates</b></summary>
 
 The control app's Location setting handles geocoding for most users (it accepts city names, postal codes, and has an Advanced panel for raw coordinates). If you'd rather edit the file directly — for example on a DIY install — set `WEATHER_LATITUDE` and `WEATHER_LONGITUDE` in `env.sh`.
 
@@ -203,21 +174,13 @@ Finding coordinates:
 - **[latlong.net](https://www.latlong.net/)**: search an address and copy the values.
 - **iPhone**: open the Compass app; coordinates are at the bottom.
 - **Android**: long-press your location in Google Maps; coordinates appear at the top.
+</details>
 
-## Manual Run
-
-```bash
-cd /home/pi/litclock
-./scripts/runtheclock.sh
-```
-
-## Updating
+### Updating
 
 **Short version:** you don't need to do anything. The clock updates itself.
 
-### Updates
-
-LitClock pulls the latest blessed release **once a week, Sunday 03:00 local time, with up to 7 days of randomization** so the fleet doesn't all update at the same moment. Each device rolls its own offset in the [0s, 7d] window — most devices pick up a new release within 1–7 days of it being cut. You can also apply an update immediately from the control app's **Updates** tab.
+LitClock pulls the latest blessed release **once a week, Sunday 03:00 local time, with up to 7 days of randomization** so the fleet doesn't all update at the same moment. You can also apply an update immediately from the control app's **Updates** tab, or from a shell: `/home/pi/litclock/scripts/update.sh`.
 
 What updates automatically:
 - LitClock code (clock logic, control app, setup server, shell scripts)
@@ -233,17 +196,8 @@ Two safety nets protect every update:
 - A **pre-wiring smoke test**: after rebuilding the venv, the updater renders an in-memory quote image. If the render fails, the update reverts to the previous SHA before touching the running clock. If that happens, a subtle "!" glyph appears in the top-right corner of the clock face until the next successful update.
 - A **boot check with automatic rollback**: if the clock ever boots and can't paint a quote, it retries, and after repeated failures automatically reinstalls the last release that is known to have painted. A bad update can't brick a clock that has no keyboard and no SSH.
 
-### Manual update (optional)
-
-Use the control app's **Updates** tab, or from a shell:
-
-```bash
-/home/pi/litclock/scripts/update.sh
-```
-
-Non-interactive and idempotent. Stops the timer, resolves the latest blessed release SHA (via the GitHub Releases API), pulls, rebuilds the venv if requirements changed, smoke-tests the render, re-applies systemd units, refreshes the display, and restarts the timer. Your `env.sh` configuration is preserved; any new env vars from `env.sh.sample` are merged automatically.
-
-### Inspection
+<details>
+<summary><b>Inspecting or opting out of auto-updates</b></summary>
 
 Check when the timer last fired and its next scheduled run:
 
@@ -257,31 +211,69 @@ See the logs of the last update attempt:
 journalctl -u litclock-update.service --since "1 week ago"
 ```
 
-### Opt-out
-
 If you'd rather manage updates yourself, disable the timer via SSH:
 
 ```bash
 sudo systemctl disable --now litclock-update.timer
 ```
 
-The clock keeps working on whatever SHA it's pinned to. The `scripts/update.sh` script and the app's Updates tab still work for manual runs. You can re-enable the timer later with:
+The clock keeps working on whatever SHA it's pinned to; manual updates via the app or `update.sh` still work, and the updater respects a manually-disabled timer — it won't silently re-enable it. Re-enable with `sudo systemctl enable --now litclock-update.timer`.
+</details>
+
+### Resetting
+
+Most resets don't need a shell — use the control app's **System** tab:
+
+- **Reset WiFi** — forget saved networks and return to the setup hotspot (settings and quote history are kept)
+- **Factory reset** — wipe all settings and start over from the first-boot experience
+- **Prepare for Gifting** — wipe WiFi, write a welcome message for the recipient, and power off ready to box up
+
+From a shell, the equivalent is:
 
 ```bash
-sudo systemctl enable --now litclock-update.timer
+sudo ./scripts/reset-setup.sh
+sudo reboot
 ```
 
-The update installer respects a manually-disabled timer — it won't silently re-enable it.
+Flags:
+- `--yes` — skip the confirmation prompt
+- `--reboot` — reboot automatically after reset
+- `--wipe-wifi` — also delete saved WiFi networks (full fresh-flash simulation)
+- `--gift-mode` — prepare for shipping: wipes WiFi, paints a welcome splash on the e-ink, and powers off. Implies `--wipe-wifi --yes`.
 
-### Fresh image
+### Troubleshooting
 
-For a fresh image, use the downloadable `.img.xz` (Option 1 above) — the installer and update script are only for existing Raspberry Pi OS installations.
+**Start here (no shell needed):** open the control app → **Diagnostics** tab. It shows version, last render time, WiFi + weather status, error flags, and recent logs. Screenshot it, or use "Download full logs" to export a redacted support bundle safe to attach to an issue.
 
-## Creating SD Cards for Friends & Family
+- **Wrong city, units, or timezone**: fix it in the app → Settings. If setup couldn't detect your location at all (some networks block IP geolocation), the app offers a one-tap "use my browser's timezone" fallback so the clock runs correctly with weather off.
+- **Display not updating**: Check SPI is enabled with `ls /dev/spi*`
+- **Check service status**: `systemctl status litclock.timer`
+- **View service logs**: `journalctl -u litclock.service --since today`
+- **Force weather update**: `rm /home/pi/litclock/weather-cache*.json`
+- **WiFi disconnects (Pi Zero)**: see [WiFi stability](#wifi-stability-pi-zero-w--zero-2-w), or check `dmesg | grep brcmfmac` for errors
+- **WiFi fails during setup**: The setup page shows an error banner and lets you fix the password and resubmit. If it keeps failing, restart the Pi closer to your router.
+- **Start setup over**: app → System → Factory reset, or `sudo ./scripts/reset-setup.sh && sudo reboot` from a shell
+- **Clock stuck, or you need a shell**: SSH ships **off**. See **[Recovering a LitClock](docs/recovery.md)** for getting a shell via the console, enabling SSH from the SD card, resetting to first-boot, and the read-only Diagnostics tab.
 
-The control app's **System → Prepare for Gifting** wipes your WiFi, writes an optional welcome message, and powers the clock down ready to box up. Print the **[quick-start booklet](docs/manual/)** to enclose with it. To duplicate SD cards instead, see **[SD Card Cloning](docs/sd-card-cloning.md)**.
+For hardware issues, refer to the [Waveshare wiki](https://www.waveshare.com/wiki/7.5inch_e-Paper_HAT) and [demo repository](https://github.com/waveshare/e-Paper).
 
-## How It Works
+## Give one away
+
+LitClock is designed to be gifted to someone who will never open a terminal:
+
+1. In the control app: **System → Prepare for Gifting** — wipes your WiFi, writes an optional welcome message, and powers the clock down ready to box up
+2. Print the **[quick-start booklet](docs/manual/)** and enclose it — one folded sheet covers everything the recipient needs
+3. The recipient plugs it in and gets the same two-minute setup you did, on their own WiFi
+
+To produce several clocks, see **[SD Card Cloning](docs/sd-card-cloning.md)** for duplicating pre-configured cards. (If *you* received a pre-configured card: just insert it and power on — setup starts at the hotspot step.)
+
+## Under the hood
+
+### Philosophy
+
+LitClock is not an SSH-optional developer tool. If you are a non-technical user, you should never need to do anything after first boot: everything configures itself, updates itself, and recovers itself. If you are a technically comfortable user, you can enable SSH (it ships off — see [Recovering a LitClock](docs/recovery.md)) and disable or customize any of this. That's why updates are silent and automatic, why the failure story is automatic rollback rather than error messages, and why day-to-day control happens from a phone rather than a terminal.
+
+### How it works
 
 On boot, the clock goes through this sequence:
 
@@ -320,50 +312,51 @@ journalctl -u litclock.service -f
 
 # Manually trigger a display update
 sudo systemctl start litclock.service
+
+# Run the clock by hand
+cd /home/pi/litclock && ./scripts/runtheclock.sh
 ```
 
-## Script Reference
+### WiFi Stability (Pi Zero W / Zero 2 W)
 
-For a full list of scripts and their usage, see **[Script Reference](docs/script-reference.md)**.
+The Raspberry Pi Zero W and Zero 2 W have a known WiFi stability issue with the BCM43430 chip that can cause the system to hang and become unreachable. The flashed image applies mitigations out of the box, and the DIY installer detects the hardware and offers them:
 
-## Resetting the Clock
+- **Driver parameters**: Disables roaming and problematic power features
+- **Power management**: Disables WiFi power saving
+- **Watchdog**: Automatically reboots if WiFi becomes unreachable
 
-Most resets don't need a shell — use the control app's **System** tab:
+If you experience WiFi disconnections or system hangs, re-run the installer to re-apply the fixes.
 
-- **Reset WiFi** — forget saved networks and return to the setup hotspot (settings and quote history are kept)
-- **Factory reset** — wipe all settings and start over from the first-boot experience
-- **Prepare for Gifting** — wipe WiFi, write a welcome message for the recipient, and power off ready to box up
+### Going deeper
 
-From a shell, the equivalent is:
+- **[Script Reference](docs/script-reference.md)** — every script and its usage
+- **[Building the Image](docs/building-image.md)** — build your own `.img.xz` from source
+- **[SD Card Cloning](docs/sd-card-cloning.md)** — duplicating configured cards
+- **[Recovering a LitClock](docs/recovery.md)** — console access, enabling SSH, reset paths
 
-```bash
-sudo ./scripts/reset-setup.sh
-sudo reboot
-```
+## Credits
 
-Flags:
-- `--yes` — skip the confirmation prompt
-- `--reboot` — reboot automatically after reset
-- `--wipe-wifi` — also delete saved WiFi networks (full fresh-flash simulation)
-- `--gift-mode` — prepare for shipping: wipes WiFi, paints a welcome splash on the e-ink, and powers off. When the recipient first plugs in the device, they see a friendly welcome and setup steps instead of "Powered Off". Implies `--wipe-wifi --yes`.
+This project was originally forked from [jadonn/literary-clock](https://github.com/jadonn/literary-clock) and has since been extensively rewritten. The literary clock concept originates from [Jaap Meijers's Instructables project](https://www.instructables.com/Literary-Clock-Made-From-E-reader/) (2018).
 
-For a full reset (including WiFi) for cloning SD cards, use `scripts/prepare-for-cloning.sh` instead (see [SD Card Cloning](docs/sd-card-cloning.md)).
+**Quote database sources:**
+- [JohannesNE/literature-clock](https://github.com/JohannesNE/literature-clock) (CC BY-NC-SA 2.5)
+- [cdmoro/literature-clock](https://github.com/cdmoro/literature-clock) (MIT)
+- [The Guardian "Books blog" reader thread](https://www.theguardian.com/books/booksblog/2011/apr/21/literary-clock) — community-sourced time-referential quotes from the 2011–2018 reader comments
 
-## Troubleshooting
+**Case design:**
+- [Arthur Gassner's Time Teller](https://github.com/arthurgassner/timeteller) (CC BY) — the 3D-printed case; lightly modified STLs ship in [`3d-models/`](3d-models/)
 
-**Start here (no shell needed):** open the control app (`http://litclock.local`) → **Diagnostics** tab. It shows version, last render time, WiFi + weather status, error flags, and recent logs — everything below, without SSH. Screenshot it, or use "Download full logs" to export a redacted support bundle safe to attach to an issue.
+**Code & display inspiration:**
+- [Jake Krajewski's Raspberry Pi + e-Paper Tutorial](https://medium.com/swlh/create-an-e-paper-display-for-your-raspberry-pi-with-python-2b0de7c8820c)
+- [Mendhak's Waveshare e-Paper Display](https://github.com/mendhak/waveshare-epaper-display) (MIT)
 
-- **Wrong city, units, or timezone**: fix it in the app → Settings. If setup couldn't detect your location at all (some networks block IP geolocation), the app offers a one-tap "use my browser's timezone" fallback so the clock runs correctly with weather off.
-- **Display not updating**: Check SPI is enabled with `ls /dev/spi*`
-- **Check service status**: `systemctl status litclock.timer`
-- **View service logs**: `journalctl -u litclock.service --since today`
-- **Force weather update**: `rm /home/pi/litclock/weather-cache*.json`
-- **WiFi disconnects (Pi Zero)**: Re-run installer and accept WiFi stability fixes, or check `dmesg | grep brcmfmac` for errors
-- **WiFi fails during setup**: The setup page shows an error banner and lets you fix the password and resubmit. If it keeps failing, restart the Pi closer to your router.
-- **Start setup over**: app → System → Factory reset, or `sudo ./scripts/reset-setup.sh && sudo reboot` from a shell
-- **Clock stuck, or you need a shell**: SSH ships **off**. See **[Recovering a LitClock](docs/recovery.md)** for getting a shell via the console, enabling SSH from the SD card, resetting to first-boot, and the read-only Diagnostics tab.
+**Assets:**
+- [Dhole's Monochrome Weather Icons](https://github.com/Dhole/weather-pixel-icons) (CC BY-SA 4.0)
+- [Google Fonts](https://fonts.google.com) — Literata (OFL 1.1)
 
-For hardware issues, refer to the [Waveshare wiki](https://www.waveshare.com/wiki/7.5inch_e-Paper_HAT) and [demo repository](https://github.com/waveshare/e-Paper).
+See [NOTICE.md](NOTICE.md) for full license details on third-party components.
+
+> LitClock was developed privately before this repository was published, so issue/PR numbers referenced in the [CHANGELOG](CHANGELOG.md) predate the public issue tracker.
 
 ## Disclaimer
 

--- a/README.md
+++ b/README.md
@@ -68,13 +68,14 @@ The installer and updater are for existing OS installs only; for a fresh SD card
 Print-ready STLs are in [`3d-models/`](3d-models/) — three PLA parts, lightly modified from [Arthur Gassner's Time Teller](https://timeteller.arthurgassner.com) case design (CC BY). Then:
 
 1. Connect the e-Paper HAT to the Pi's 40-pin header, and the display to the HAT via the ribbon cable
-2. Assemble the case around it — threaded inserts, the USB-C adapter on the back, screws
+2. Insert the flashed SD card into the Pi — do this **before** closing the case
+3. Assemble the case — threaded inserts, the USB-C adapter on the back, screws
 
 Arthur's guide covers the case assembly beautifully, and our **[Hardware Assembly](docs/hardware-assembly.md)** page has the LitClock-specific details (ribbon-cable orientation, e-ink handling notes). No case? The bare HAT sandwich works fine on a shelf while you decide.
 
 ### 4. Power on — two-minute setup
 
-1. Insert the SD card and power on. Within a minute the display shows a **"LitClock-Setup"** hotspot with its password and a QR code.
+1. Power on. Within a minute the display shows a **"LitClock-Setup"** hotspot with its password and a QR code.
 2. Join the hotspot from your phone — the setup page opens automatically (or browse to the address shown on the display).
 3. Pick your home WiFi and enter its password. **That's the whole form** — location, timezone, and temperature units auto-detect once the clock is online.
 4. The display shows "Ready to read." with a QR code to the clock's control app. Scan it, tap **"Done — Start the Clock"** (or just wait — it starts on its own), and add the app to your home screen.
@@ -106,13 +107,13 @@ Anything the auto-detection got wrong — city, units, mature-content filter —
 
 Every LitClock serves a small web app on your home network at **`http://litclock.local`** (or the clock's IP — the QR in the corner of every quote points there). Open it in any browser, or add it to your phone's home screen. No account, no cloud — the app is served by the clock itself and works only on your LAN.
 
-| Tab | What it does |
+| Screen | What it does |
 |-----|--------------|
 | **Status** | Current quote, weather, WiFi, and version at a glance |
 | **Settings** | Location (automatic by IP, or type any place worldwide), weather on/off, Fahrenheit/Celsius, mature-content filter |
 | **Updates** | Current version, release notes, and a button to apply an update now |
 | **System** | Restart, power off, reset WiFi, factory reset, and "Prepare for Gifting" |
-| **Diagnostics** | Read-only health panel: last render, network, services, recent logs, and a downloadable support-log bundle |
+| **Diagnostics** (separate page) | Read-only health panel at `/diagnostics` — last render, network, services, recent logs, and a downloadable support-log bundle. Linked from the app's live-status ribbon |
 
 <p align="center">
   <img src="docs/images/pwa-status.png" alt="Status tab — current quote, weather, version" width="260">
@@ -193,7 +194,7 @@ What does NOT update automatically — **by design**:
 - OS packages (`apt upgrade`) and Raspberry Pi firmware. On the flashed image, OS auto-updates are explicitly disabled: a surprise apt upgrade could break the display stack with nobody at the keyboard. OS-level updates happen when you flash a newer image (or run them yourself over SSH).
 
 Two safety nets protect every update:
-- A **pre-wiring smoke test**: after rebuilding the venv, the updater renders an in-memory quote image. If the render fails, the update reverts to the previous SHA before touching the running clock. If that happens, a subtle "!" glyph appears in the top-right corner of the clock face until the next successful update.
+- A **pre-wiring smoke test**: after rebuilding the venv, the updater renders an in-memory quote image. If the render fails, the update reverts to the previous SHA before touching the running clock. If that happens, a subtle "!" glyph appears in the top-left corner of the clock face until the next successful update.
 - A **boot check with automatic rollback**: if the clock ever boots and can't paint a quote, it retries, and after repeated failures automatically reinstalls the last release that is known to have painted. A bad update can't brick a clock that has no keyboard and no SSH.
 
 <details>
@@ -224,7 +225,7 @@ The clock keeps working on whatever SHA it's pinned to; manual updates via the a
 
 Most resets don't need a shell — use the control app's **System** tab:
 
-- **Reset WiFi** — forget saved networks and return to the setup hotspot (settings and quote history are kept)
+- **Reset WiFi** — forget saved networks and return to the setup hotspot (your settings — location, weather, gift mode — are kept)
 - **Factory reset** — wipe all settings and start over from the first-boot experience
 - **Prepare for Gifting** — wipe WiFi, write a welcome message for the recipient, and power off ready to box up
 
@@ -243,13 +244,13 @@ Flags:
 
 ### Troubleshooting
 
-**Start here (no shell needed):** open the control app → **Diagnostics** tab. It shows version, last render time, WiFi + weather status, error flags, and recent logs. Screenshot it, or use "Download full logs" to export a redacted support bundle safe to attach to an issue.
+**Start here (no shell needed):** open `http://litclock.local/diagnostics` (or tap "Open full diagnostics" in the control app). It shows version, last render time, WiFi + weather status, error flags, and recent logs. Screenshot it, or use "Download full logs" to export a redacted support bundle safe to attach to an issue.
 
 - **Wrong city, units, or timezone**: fix it in the app → Settings. If setup couldn't detect your location at all (some networks block IP geolocation), the app offers a one-tap "use my browser's timezone" fallback so the clock runs correctly with weather off.
 - **Display not updating**: Check SPI is enabled with `ls /dev/spi*`
 - **Check service status**: `systemctl status litclock.timer`
 - **View service logs**: `journalctl -u litclock.service --since today`
-- **Force weather update**: `rm /home/pi/litclock/weather-cache*.json`
+- **Force weather update**: `rm /run/litclock/weather-cache-*.json` (the cache lives in tmpfs and rebuilds on the next minute tick)
 - **WiFi disconnects (Pi Zero)**: see [WiFi stability](#wifi-stability-pi-zero-w--zero-2-w), or check `dmesg | grep brcmfmac` for errors
 - **WiFi fails during setup**: The setup page shows an error banner and lets you fix the password and resubmit. If it keeps failing, restart the Pi closer to your router.
 - **Start setup over**: app → System → Factory reset, or `sudo ./scripts/reset-setup.sh && sudo reboot` from a shell
@@ -271,7 +272,7 @@ To produce several clocks, see **[SD Card Cloning](docs/sd-card-cloning.md)** fo
 
 ### Philosophy
 
-LitClock is not an SSH-optional developer tool. If you are a non-technical user, you should never need to do anything after first boot: everything configures itself, updates itself, and recovers itself. If you are a technically comfortable user, you can enable SSH (it ships off — see [Recovering a LitClock](docs/recovery.md)) and disable or customize any of this. That's why updates are silent and automatic, why the failure story is automatic rollback rather than error messages, and why day-to-day control happens from a phone rather than a terminal.
+LitClock is an appliance, not an SSH-first developer tool. If you are a non-technical user, you should never need to do anything after first boot: everything configures itself, updates itself, and recovers itself. If you are a technically comfortable user, you can enable SSH (it ships off — see [Recovering a LitClock](docs/recovery.md)) and disable or customize any of this. That's why updates are silent and automatic, why the failure story is automatic rollback rather than error messages, and why day-to-day control happens from a phone rather than a terminal.
 
 ### How it works
 

--- a/docs/script-reference.md
+++ b/docs/script-reference.md
@@ -9,9 +9,9 @@ Scripts are organized into `scripts/` (shell) and `src/` (Python):
 | `src/clear.py` | `python3 src/clear.py` | Clear the e-ink display to white |
 | `src/wifi_provision.py` | `python3 src/wifi_provision.py [flags]` | WiFi provisioning via captive portal hotspot |
 | `scripts/update.sh` | `./scripts/update.sh` | Pull latest code and apply updates in-place |
-| `scripts/reset-setup.sh` | `sudo ./scripts/reset-setup.sh [--yes] [--reboot] [--wipe-wifi] [--gift-mode]` | Reset configuration (see [Resetting the Clock](../README.md#resetting-the-clock)); `--gift-mode` preps the device for shipping with a welcome splash |
+| `scripts/reset-setup.sh` | `sudo ./scripts/reset-setup.sh [--yes] [--reboot] [--wipe-wifi] [--gift-mode]` | Reset configuration (see [Resetting the Clock](../README.md#resetting)); `--gift-mode` preps the device for shipping with a welcome splash |
 | `scripts/prepare-for-cloning.sh` | `sudo ./scripts/prepare-for-cloning.sh` | Wipe config and credentials for SD card cloning (see [Creating SD Cards](sd-card-cloning.md)) |
-| `scripts/install.sh` | `curl -sSL <url> \| bash` | One-line installer (see [DIY Installation](../README.md#option-2-diy-installation-terminal-required)) |
+| `scripts/install.sh` | `curl -sSL <url> \| bash` | One-line installer (see [DIY Installation](../README.md#2-flash-the-sd-card)) |
 
 ## eink_display.py subcommands
 

--- a/docs/sd-card-cloning.md
+++ b/docs/sd-card-cloning.md
@@ -6,7 +6,7 @@ If you want to make pre-configured SD cards from a working clock:
 
 ## 1. Set Up a Working Clock First
 
-Complete the full installation on one Pi using [Option 2 (DIY Installation)](../README.md#option-2-diy-installation-terminal-required). Verify everything works.
+Complete the full installation on one Pi using [Option 2 (DIY Installation)](../README.md#2-flash-the-sd-card). Verify everything works.
 
 ## 2. Prepare for Cloning
 


### PR DESCRIPTION
The README served three readers (evaluator / builder / owner) in an order that suited none of them — a builder hit Philosophy and 23 lines of Credits before learning what to buy, and the assembly step existed only as a link sequenced in the wrong place.

New shape, self-routing from a mini-TOC in the hero:

- **Build one** — the numbered spine: parts table (inlined) → flash → print & assemble (Arthur's guide + ours linked at the step, case credit inline) → power on & two-minute setup (screenshots live here)
- **Living with it** — Control App, Configuration, Updating, Resetting, Troubleshooting; advanced/opt-out material folded into `<details>`
- **Give one away** — gifting, booklet, and SD-cloning consolidated from three scattered fragments
- **Under the hood** — full Philosophy, How It Works (+ frame anatomy, services table), WiFi stability, deeper-doc links
- **Credits** (moved from position #5 to the end) and Disclaimer

Content is rearranged, not rewritten — no new claims to fact-check. Two small fixes along the way: the stale "issue #8" link in WiFi stability (predates the public tracker) is replaced with self-contained guidance, and Manual Run folded into the useful-commands block.