### PR TITLE
fix(control): self-heal port-80 floor so control_server can't crash-loop into a brick

### DIFF
--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -1226,21 +1226,36 @@ sudo systemctl start litclock.timer
 # loudly if it didn't take, rather than silently move control_server onto an
 # unbindable port (the unit's StartLimitIntervalSec=0 + the persisted file mean
 # the next reboot self-heals, but the operator should know).
+_SYSCTL_CONF=/etc/sysctl.d/30-litclock-unprivileged-ports.conf
 if [[ -f "$INSTALL_DIR/sysctl.d/30-litclock-unprivileged-ports.conf" ]]; then
     sudo install -m 0644 -o root -g root \
         "$INSTALL_DIR/sysctl.d/30-litclock-unprivileged-ports.conf" \
-        /etc/sysctl.d/30-litclock-unprivileged-ports.conf 2>/dev/null || true
+        "$_SYSCTL_CONF" 2>/dev/null || true
     sudo sysctl -w net.ipv4.ip_unprivileged_port_start=80 > /dev/null 2>&1 || true
     # Read the live value from /proc, NOT `sysctl -n`: sysctl lives in /usr/sbin
     # which is not on the pi user's non-login PATH, so `sysctl -n` here returns
     # "command not found" and a false "could not lower floor" warning (caught in
     # #343 hardware QA). The /proc file is always readable with no PATH/sudo.
     _port_floor=$(cat /proc/sys/net/ipv4/ip_unprivileged_port_start 2>/dev/null || echo "")
+    # litclock-dev#527 field incident: the FILE install was silently swallowed
+    # (2>/dev/null || true) while `sysctl -w` set the live value to 80 — so the
+    # old warning (live-value only) stayed quiet, the update "succeeded", and the
+    # NEXT reboot reverted to 1024 and crash-looped control_server. Check the
+    # persisted file explicitly, independent of the live value, so a failed
+    # install can never pass silently again. (litclock-control.service also
+    # self-heals the live value via ExecStartPre now — this warning is the
+    # human-visible half.)
+    if [[ ! -f "$_SYSCTL_CONF" ]]; then
+        echo "  WARNING (#343/#527): the persistent port-80 sysctl drop-in did not"
+        echo "  install ($_SYSCTL_CONF is missing). The live floor may be 80 now but"
+        echo "  will revert on reboot. Re-run: sudo install -m 0644 -o root -g root \\"
+        echo "    $INSTALL_DIR/sysctl.d/30-litclock-unprivileged-ports.conf $_SYSCTL_CONF"
+    fi
     if [[ "$_port_floor" != "80" ]]; then
         echo "  WARNING (#343): could not lower the unprivileged-port floor to 80"
         echo "  (net.ipv4.ip_unprivileged_port_start=${_port_floor:-unknown}). The Control"
         echo "  PWA may be unreachable on port 80 until the next reboot applies the"
-        echo "  installed /etc/sysctl.d/30-litclock-unprivileged-ports.conf."
+        echo "  installed $_SYSCTL_CONF."
     fi
 fi
 

--- a/systemd/litclock-control.service
+++ b/systemd/litclock-control.service
@@ -26,6 +26,17 @@ ConditionPathExists=/etc/litclock/.setup-complete
 Type=simple
 User=pi
 WorkingDirectory=/home/pi/litclock
+# Self-heal the port-80 bind precondition on every start (#343 follow-up,
+# litclock-dev#527). control_server binds port 80 as the non-root `pi` user,
+# which only works when net.ipv4.ip_unprivileged_port_start<=80. If the
+# persistent /etc/sysctl.d drop-in ever fails to apply — a silently-swallowed
+# install failure in an OTA (the field incident), a boot-order race, a manual
+# sysctl reset — the floor reverts to 1024 and this service crash-loops on
+# EACCES with no recovery path for a keyboard-less owner. The `+` runs this one
+# line as root (the unit is NoNewPrivileges=no); `-` tolerates its absence in
+# sandboxed test contexts. Idempotent and ~1ms, so paying it every start is
+# free insurance against the whole class.
+ExecStartPre=+-/usr/sbin/sysctl -q net.ipv4.ip_unprivileged_port_start=80
 ExecStart=/home/pi/litclock/venv/bin/python3 /home/pi/litclock/src/control_server/app.py
 Restart=on-failure
 RestartSec=5

--- a/tests/test_systemd_units.py
+++ b/tests/test_systemd_units.py
@@ -537,6 +537,24 @@ class TestControlServiceUnitShape:
         unit = parse_unit("litclock-control.service")
         assert unit.get("Service", "User") == "pi"
 
+    def test_self_heals_port80_floor_before_start(self):
+        """litclock-dev#527: the service binds port 80 as non-root `pi`, which
+        needs net.ipv4.ip_unprivileged_port_start<=80. If the persistent
+        sysctl drop-in ever fails to apply (silent OTA install failure, boot
+        race), the floor reverts to 1024 and the service crash-loops on EACCES
+        with no recovery path for a keyboard-less owner. An ExecStartPre must
+        re-assert the floor as root (`+`) on every start so this class is
+        unbrickable. Read raw text: configparser collapses duplicate keys."""
+        path = os.path.join(SYSTEMD_DIR, "litclock-control.service")
+        with open(path) as f:
+            body = f.read()
+        assert "ExecStartPre=+" in body and "ip_unprivileged_port_start=80" in body, (
+            "litclock-control.service must self-heal the port-80 floor via an "
+            "ExecStartPre=+...sysctl before ExecStart (litclock-dev#527)"
+        )
+        # The precondition must precede ExecStart in file order.
+        assert body.index("ExecStartPre=+") < body.index("ExecStart="), "ExecStartPre must appear before ExecStart"
+
     def test_starts_after_firstboot(self):
         unit = parse_unit("litclock-control.service")
         after = unit.get("Unit", "After", fallback="")


### PR DESCRIPTION
**Field incident**: a clock spent 8.5 hours crash-looping (restart counter 6,096) with its Control PWA unreachable. Root cause, confirmed from device diagnostics:

An OTA's port-80 sysctl phase ran `sudo sysctl -w …=80` (set the LIVE value, printed no warning) but the persistent `/etc/sysctl.d` drop-in install **failed silently** (`2>/dev/null || true`). The phase's only warning checks the live value, so the update reported success. The next reboot reverted the floor to 1024, and `litclock-control` (which binds port 80 as non-root `pi`) crash-looped on EACCES. A non-technical owner has no recovery path — the PWA is how you'd fix it, and the PWA is what's down.

**Fix (belt + suspenders):**
1. **`litclock-control.service` self-heals** — `ExecStartPre=+-/usr/sbin/sysctl -q net.ipv4.ip_unprivileged_port_start=80` re-asserts the floor as root (`+`; the unit is `NoNewPrivileges=no`) on every start. Idempotent, ~1ms. The service can never crash-loop on this class again, however the persistent file got lost (silent OTA failure, boot-order race, manual reset).
2. **`update.sh` stops swallowing** — a new warning checks the persisted FILE explicitly, independent of the live value, and prints the exact re-install command. A failed install can't pass silently again.
3. A **systemd unit test** pins the ExecStartPre so a future edit can't drop it.

2668 tests pass; `bash -n` clean; the new unit test covers the ExecStartPre presence + ordering. Investigation record: litclock-dev#527.