### PR TITLE
fix(control): /review follow-ups on the port-80 self-heal (#15)

### DIFF
--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -1240,14 +1240,17 @@ if [[ -f "$INSTALL_DIR/sysctl.d/30-litclock-unprivileged-ports.conf" ]]; then
     # litclock-dev#527 field incident: the FILE install was silently swallowed
     # (2>/dev/null || true) while `sysctl -w` set the live value to 80 — so the
     # old warning (live-value only) stayed quiet, the update "succeeded", and the
-    # NEXT reboot reverted to 1024 and crash-looped control_server. Check the
-    # persisted file explicitly, independent of the live value, so a failed
-    # install can never pass silently again. (litclock-control.service also
-    # self-heals the live value via ExecStartPre now — this warning is the
+    # NEXT reboot reverted to 1024 and crash-looped control_server. Verify the
+    # persisted file matches the source CONTENT, not just its existence: a
+    # stale drop-in left by a prior version whose fresh overwrite then failed
+    # (RO fs, disk full) would pass a mere `-f` check while being wrong
+    # (/review, both passes). `cmp -s` is true only when the installed file is
+    # byte-identical to what we shipped. (litclock-control.service also
+    # self-heals the live value via ExecStartPre — this warning is the
     # human-visible half.)
-    if [[ ! -f "$_SYSCTL_CONF" ]]; then
-        echo "  WARNING (#343/#527): the persistent port-80 sysctl drop-in did not"
-        echo "  install ($_SYSCTL_CONF is missing). The live floor may be 80 now but"
+    if ! cmp -s "$INSTALL_DIR/sysctl.d/30-litclock-unprivileged-ports.conf" "$_SYSCTL_CONF"; then
+        echo "  WARNING (#343/#527): the persistent port-80 sysctl drop-in is"
+        echo "  missing or stale at $_SYSCTL_CONF. The live floor may be 80 now but"
         echo "  will revert on reboot. Re-run: sudo install -m 0644 -o root -g root \\"
         echo "    $INSTALL_DIR/sysctl.d/30-litclock-unprivileged-ports.conf $_SYSCTL_CONF"
     fi

--- a/systemd/litclock-control.service
+++ b/systemd/litclock-control.service
@@ -33,9 +33,12 @@ WorkingDirectory=/home/pi/litclock
 # install failure in an OTA (the field incident), a boot-order race, a manual
 # sysctl reset — the floor reverts to 1024 and this service crash-loops on
 # EACCES with no recovery path for a keyboard-less owner. The `+` runs this one
-# line as root (the unit is NoNewPrivileges=no); `-` tolerates its absence in
-# sandboxed test contexts. Idempotent and ~1ms, so paying it every start is
-# free insurance against the whole class.
+# line as root, independent of the unit's User=pi/NoNewPrivileges wiring (it
+# bypasses that, doesn't depend on it); `-` ignores a failed/absent sysctl so
+# the pre-start can't itself become a start-failure. Defense-in-depth on top of
+# the boot-time drop-in — not a standalone guarantee: if BOTH the drop-in is
+# missing AND this sysctl write fails (a root write of a standard kernel knob —
+# near-impossible), the EACCES loop can still occur. Idempotent, ~1ms.
 ExecStartPre=+-/usr/sbin/sysctl -q net.ipv4.ip_unprivileged_port_start=80
 ExecStart=/home/pi/litclock/venv/bin/python3 /home/pi/litclock/src/control_server/app.py
 Restart=on-failure

--- a/tests/test_systemd_units.py
+++ b/tests/test_systemd_units.py
@@ -539,21 +539,30 @@ class TestControlServiceUnitShape:
 
     def test_self_heals_port80_floor_before_start(self):
         """litclock-dev#527: the service binds port 80 as non-root `pi`, which
-        needs net.ipv4.ip_unprivileged_port_start<=80. If the persistent
-        sysctl drop-in ever fails to apply (silent OTA install failure, boot
-        race), the floor reverts to 1024 and the service crash-loops on EACCES
-        with no recovery path for a keyboard-less owner. An ExecStartPre must
-        re-assert the floor as root (`+`) on every start so this class is
-        unbrickable. Read raw text: configparser collapses duplicate keys."""
+        needs net.ipv4.ip_unprivileged_port_start<=80. If the persistent sysctl
+        drop-in fails to apply (silent OTA install failure, boot race), the
+        floor reverts to 1024 and the service crash-loops on EACCES with no
+        recovery path for a keyboard-less owner. An ExecStartPre re-asserts the
+        floor as a defense-in-depth backstop on the boot-time drop-in.
+
+        Pin BOTH prefixes (post-/review, Claude+Codex): `+` (run as root) AND
+        `-` (ignore failure). Dropping `-` is the subtle regression — it turns
+        a sysctl failure into a hard start-failure, a NEW crash-loop vector the
+        `-` exists to prevent — and a prefix-agnostic assertion would wave it
+        through. Read raw text: configparser collapses duplicate keys."""
         path = os.path.join(SYSTEMD_DIR, "litclock-control.service")
         with open(path) as f:
             body = f.read()
-        assert "ExecStartPre=+" in body and "ip_unprivileged_port_start=80" in body, (
-            "litclock-control.service must self-heal the port-80 floor via an "
-            "ExecStartPre=+...sysctl before ExecStart (litclock-dev#527)"
+        assert "ExecStartPre=+-/usr/sbin/sysctl" in body and "ip_unprivileged_port_start=80" in body, (
+            "litclock-control.service must self-heal the port-80 floor via "
+            "`ExecStartPre=+-/usr/sbin/sysctl ...=80` — both the `+` (root) and "
+            "`-` (ignore-failure) prefixes are load-bearing (litclock-dev#527)"
         )
-        # The precondition must precede ExecStart in file order.
-        assert body.index("ExecStartPre=+") < body.index("ExecStart="), "ExecStartPre must appear before ExecStart"
+        # NB: file ORDER of ExecStartPre vs ExecStart is deliberately NOT
+        # asserted — systemd runs every ExecStartPre before ExecStart by
+        # directive semantics regardless of line position, so a line-order
+        # check would guard a non-invariant and give false confidence
+        # (/review finding, Claude pass).
 
     def test_starts_after_firstboot(self):
         unit = parse_unit("litclock-control.service")


### PR DESCRIPTION
Post-merge `/review` of #15 (Codex + independent Claude adversarial pass). **Both models: the runtime fix is correct, no crash-loop reintroduced.** These close the four precision/coverage gaps they surfaced — none are runtime bugs:

1. **Test now pins both `ExecStartPre` prefixes** (`+` root, `-` ignore-failure). The original assertion checked only `+`, so a future edit dropping `-` — which converts a sysctl failure into a hard start-failure, a *new* crash-loop vector the `-` exists to prevent — passed silently. Verified: the tightened check rejects the dash-dropped variant, the old one accepted it.
2. **Dropped a meaningless assertion**: `ExecStartPre` runs before `ExecStart` by systemd directive semantics regardless of file line order, so the line-order check guarded a non-invariant (false confidence).
3. **`update.sh` verifies content, not existence** (`cmp -s` vs `[[ -f ]]`): a stale drop-in from a prior version whose fresh overwrite failed would pass a mere existence check.
4. **Comment honesty**: the ExecStartPre is defense-in-depth on the boot-time drop-in, not the "unbrickable" standalone guarantee #15 claimed; also corrected the NoNewPrivileges-enabler imprecision (`+` bypasses that wiring, doesn't depend on it).

2668 tests pass; Codex re-reviewed this diff clean. Record: litclock-dev#527.