### PR TITLE
fix(eink): auto-fit welcome title so gift messages don't truncate

### DIFF
--- a/src/eink_display.py
+++ b/src/eink_display.py
@@ -231,7 +231,7 @@ def _wrap_title(text: str, font: ImageFont.FreeTypeFont, max_width: int, max_lin
     return kept
 
 
-def _fit_title(text: str, font_path: str, max_width: int) -> tuple[list[str], "ImageFont.FreeTypeFont"]:
+def _fit_title(text: str, font_path: str, max_width: int) -> tuple[list[str], "ImageFont.ImageFont"]:
     """Choose the largest TITLE_FIT_TIERS font at which ``text`` word-wraps
     within that tier's line budget WITHOUT ellipsis truncation, and return
     ``(lines, font)``.

--- a/src/eink_display.py
+++ b/src/eink_display.py
@@ -146,6 +146,18 @@ MAX_TITLE_LINES = 2
 TITLE_LINE_SPACING = 4
 ELLIPSIS = "…"
 
+# Auto-fit ladder for the welcome/status title (gift-message #280 truncation
+# fix). A personalized gift message must SHRINK to fit, never lose its tail to
+# an ellipsis — silently cutting "…a good time to read!" off someone's present
+# is the one place truncation is unacceptable. Each tier is (font_size,
+# max_lines); tried largest-first, the first tier whose natural wrap fits the
+# line budget wins. The top tier is the historical 48pt/2-line look, so short
+# greetings render byte-identically to before. Only the final tier permits an
+# ellipsis, for a message longer than ~4 lines at 28pt (well past the 280-char
+# input cap in practice). Envelope check: 4 lines @ 28pt ≈ 150px, which clears
+# the setup-steps block below even at the gift layout's title_y=60.
+TITLE_FIT_TIERS = ((48, 2), (44, 3), (38, 3), (32, 4), (28, 4))
+
 
 def _wrap_title(text: str, font: ImageFont.FreeTypeFont, max_width: int, max_lines: int) -> list[str]:
     """Word-wrap ``text`` into at most ``max_lines`` lines whose pixel width
@@ -219,6 +231,45 @@ def _wrap_title(text: str, font: ImageFont.FreeTypeFont, max_width: int, max_lin
     return kept
 
 
+def _fit_title(text: str, font_path: str, max_width: int) -> tuple[list[str], "ImageFont.FreeTypeFont"]:
+    """Choose the largest TITLE_FIT_TIERS font at which ``text`` word-wraps
+    within that tier's line budget WITHOUT ellipsis truncation, and return
+    ``(lines, font)``.
+
+    Iterates tiers largest-first: at a smaller font more words fit per line,
+    so the natural (untruncated) line count only shrinks as we descend — the
+    first tier whose natural wrap fits is the biggest font that shows the whole
+    message. If even the smallest tier overflows (a message far past the input
+    cap), that tier is used WITH ellipsis as a last resort. Short titles hit
+    the first tier and render exactly as the pre-fix 48pt/2-line code did.
+
+    Falls back to Pillow's default font if ``font_path`` can't be loaded (keeps
+    the hardware path from crashing on a missing font, matching the caller's
+    prior try/except contract).
+    """
+    if not text:
+        try:
+            return [], ImageFont.truetype(font_path, TITLE_FIT_TIERS[0][0])
+        except Exception:
+            return [], ImageFont.load_default()
+
+    last: tuple[list[str], ImageFont.FreeTypeFont, int] | None = None
+    for size, max_lines in TITLE_FIT_TIERS:
+        try:
+            font = ImageFont.truetype(font_path, size)
+        except Exception:
+            font = ImageFont.load_default()
+        # Natural wrap: max_lines=len(text)+1 can never truncate, so this is the
+        # untruncated line count at this font size.
+        natural = _wrap_title(text, font, max_width, len(text) + 1)
+        if len(natural) <= max_lines:
+            return natural, font
+        last = (natural, font, max_lines)
+    # Overflowed every tier — truncate at the smallest (last) tier.
+    natural, font, max_lines = last
+    return _wrap_title(text, font, max_width, max_lines), font
+
+
 def create_status_image(title: str, message: str = None, submessage: str = None) -> Image.Image:
     """
     Create a status/message display image.
@@ -235,24 +286,25 @@ def create_status_image(title: str, message: str = None, submessage: str = None)
     image = Image.new("1", DISPLAY_SIZE, 255)
     draw = ImageDraw.Draw(image)
 
-    # Load fonts
+    # Load the secondary fonts (fixed sizes). The TITLE font is chosen
+    # per-message by _fit_title below, not fixed here.
     try:
-        title_font = ImageFont.truetype(FONT_PATH_BOLD, 48)
         message_font = ImageFont.truetype(FONT_PATH, 28)
         small_font = ImageFont.truetype(FONT_PATH, 20)
     except Exception:
-        title_font = ImageFont.load_default()
         message_font = ImageFont.load_default()
         small_font = ImageFont.load_default()
 
-    # #319: word-wrap the title to MAX_TITLE_LINES at TITLE_SIDE_MARGIN
-    # gutter. Old code centered a single-line `draw.text(title)`; a 36-char
-    # personalized welcome ("This is a test message! Love, Alexis") measures
-    # ~900px wide at font 48 and rendered with a negative title_x, clipping
-    # characters off BOTH edges of the 800px canvas. Wrap + center-align
-    # keeps the text on-canvas regardless of length.
+    # #319 + #280 gift-message fix: word-wrap the title at the TITLE_SIDE_MARGIN
+    # gutter, AUTO-FITTING the font so a long personalized welcome shrinks to
+    # fit instead of losing its tail to an ellipsis. Old code centered a
+    # single-line draw.text (clipped both edges); the #319 wrap fixed the
+    # clipping but capped at 48pt/2 lines and ellipsis-truncated anything
+    # longer ("May it always be a good ti…" on a real gift). _fit_title returns
+    # both the wrapped lines and the font size it settled on; short greetings
+    # still land at 48pt/2 lines, unchanged.
     title_max_width = DISPLAY_SIZE[0] - 2 * TITLE_SIDE_MARGIN
-    title_lines = _wrap_title(title, title_font, title_max_width, MAX_TITLE_LINES)
+    title_lines, title_font = _fit_title(title, FONT_PATH_BOLD, title_max_width)
     if title_lines:
         title_block = "\n".join(title_lines)
         title_bbox = draw.multiline_textbbox(

--- a/tests/test_eink_wrap.py
+++ b/tests/test_eink_wrap.py
@@ -21,10 +21,21 @@ from eink_display import (
     DISPLAY_SIZE,
     FONT_PATH_BOLD,
     MAX_TITLE_LINES,
+    TITLE_FIT_TIERS,
     TITLE_SIDE_MARGIN,
+    _fit_title,
     _wrap_title,
     create_status_image,
 )
+
+TITLE_MAX_WIDTH = DISPLAY_SIZE[0] - 2 * TITLE_SIDE_MARGIN
+
+
+def _widths(lines, font):
+    from PIL import Image
+
+    d = ImageDraw.Draw(Image.new("1", (1, 1)))
+    return [d.textbbox((0, 0), ln, font=font)[2] - d.textbbox((0, 0), ln, font=font)[0] for ln in lines]
 
 
 def _title_font() -> ImageFont.FreeTypeFont:
@@ -358,3 +369,72 @@ class TestHandoffSplashSsidCaveat:
 
         assert image.size == DISPLAY_SIZE
         assert image.mode == "1"
+
+
+class TestFitTitleAutoShrink:
+    """#280 gift-message fix: `_fit_title` shrinks the font (and grows the line
+    budget) so a personalized welcome renders in FULL instead of losing its
+    tail to an ellipsis. Truncating "…a good time to read!" off someone's gift
+    was the field bug (hardware photo, 2026-07-15)."""
+
+    def test_short_greeting_unchanged_at_48pt_2_lines(self):
+        """Regression: a short greeting must land on the top tier (48pt, ≤2
+        lines) exactly as the pre-fix code did — no silent restyle of the
+        common case."""
+        lines, font = _fit_title("Happy Birthday Mom! Love, Alexis", FONT_PATH_BOLD, TITLE_MAX_WIDTH)
+        assert font.size == TITLE_FIT_TIERS[0][0] == 48
+        assert 1 <= len(lines) <= MAX_TITLE_LINES
+        assert "…" not in "".join(lines)
+
+    def test_the_field_bug_message_renders_in_full(self):
+        """The exact failing shape from the hardware photo (three-name
+        salutation + the pun) must render with NO ellipsis at a shrunk font."""
+        msg = "Alex, Blair & Cameron: May it always be a good time to read!"
+        lines, font = _fit_title(msg, FONT_PATH_BOLD, TITLE_MAX_WIDTH)
+        joined = " ".join(lines)
+        assert "…" not in joined, "gift message must not be truncated"
+        assert font.size < 48, "a message this long must shrink below the top tier"
+        # Every word of the original survives (order-preserving).
+        assert joined.split() == msg.split()
+        # Every line fits the canvas gutter.
+        assert all(w <= TITLE_MAX_WIDTH for w in _widths(lines, font))
+
+    def test_descending_tiers_never_increase_line_count(self):
+        """Core invariant that makes 'largest font that fits' correct: at a
+        smaller font, more words fit per line, so the natural (untruncated)
+        line count is monotonically non-increasing as tiers shrink."""
+        msg = "A moderately long personalized welcome message for the recipient"
+        prev = None
+        for size, _ in TITLE_FIT_TIERS:
+            font = ImageFont.truetype(FONT_PATH_BOLD, size)
+            natural = _wrap_title(msg, font, TITLE_MAX_WIDTH, len(msg) + 1)
+            if prev is not None:
+                assert len(natural) <= prev, f"line count rose from {prev} at smaller font {size}"
+            prev = len(natural)
+
+    def test_pathological_overflow_truncates_within_canvas(self):
+        """A message far past any real gift greeting (and the 280-char input
+        cap) degrades to the smallest tier WITH ellipsis — but every line must
+        still fit the canvas, never run off the edge."""
+        absurd = "supercalifragilistic " * 40
+        lines, font = _fit_title(absurd, FONT_PATH_BOLD, TITLE_MAX_WIDTH)
+        assert font.size == TITLE_FIT_TIERS[-1][0]
+        assert len(lines) <= TITLE_FIT_TIERS[-1][1]
+        assert "…" in "".join(lines)
+        assert all(w <= TITLE_MAX_WIDTH for w in _widths(lines, font))
+
+    def test_empty_title_is_safe(self):
+        lines, font = _fit_title("", FONT_PATH_BOLD, TITLE_MAX_WIDTH)
+        assert lines == []
+        assert font.size == 48
+
+    def test_status_image_renders_long_gift_without_crash(self):
+        """End-to-end: the full gift splash (long title + multi-line steps +
+        Orwell footer) renders to a valid 1-bit canvas."""
+        img = create_status_image(
+            "Alex, Blair & Cameron: May it always be a good time to read!",
+            message="1. Plug in power\n2. Connect to LitClock-Setup WiFi when prompted\n3. Be patient",
+            submessage='"It was a bright cold day in April." —Orwell',
+        )
+        assert img.size == DISPLAY_SIZE
+        assert img.mode == "1"


### PR DESCRIPTION
**Field bug** (hardware photo): a personalized gift welcome — 'Names: May it always be a good time to read!' — rendered at a fixed 48pt/2-line title and ellipsis-truncated the tail to '…a good ti'. Silently cutting the end off someone's gift message is the one place truncation is unacceptable.

**Fix:** `_fit_title` walks a `(font_size, max_lines)` ladder `((48,2),(44,3),(38,3),(32,4),(28,4))` largest-first and returns the biggest tier whose natural word-wrap fits with NO ellipsis; only the smallest tier truncates, for a message far past the 280-char input cap. Short greetings still land at 48pt/2 lines, byte-identical to before. Verified on rendered splashes: the field message now shows in full at 44pt; empty/840-char edge cases safe and within-canvas.

**Tests (+6):** the exact field-bug shape (asserts no ellipsis + word-order preserved + per-line width), the descending-tier monotonicity invariant the walk relies on, pathological-overflow-within-canvas, empty-safe, and end-to-end render.

**Reviewed:** Codex + independent Claude adversarial pass — both 'merge stands, no defects'. Fixed the one cosmetic nit they raised (return type hint). 2674 tests pass.