### PR TITLE
fix(gift): disable SSH before shipping a gifted device

### DIFF
--- a/scripts/reset-setup.sh
+++ b/scripts/reset-setup.sh
@@ -416,6 +416,35 @@ if [[ "$GIFT_MODE" == "true" ]]; then
         echo -e "${YELLOW}  sudo $0 --gift-mode${NC}"
         exit 1
     fi
+    # #528: force SSH off before shipping. The image ships SSH off, but an
+    # owner who enabled it (QA, recovery, tinkering) would otherwise hand
+    # the recipient a device with SSH listening + the well-known default
+    # creds the moment it joins THEIR network. Idempotent belt-and-
+    # suspenders across every way SSH can be on:
+    #   - ssh.socket — Raspberry Pi OS Bookworm SOCKET-ACTIVATES sshd: pid 1
+    #     holds port 22 via ssh.socket and spawns sshd per-connection.
+    #     Disabling ssh.service alone leaves the socket listening, so the
+    #     socket MUST be disabled — this is the load-bearing line on
+    #     current images (hardware QA 2026-07-16 caught a service-only
+    #     disable leaving port 22 open after reprovision). Harmless no-op
+    #     on older service-activated images.
+    #   - ssh.service — the classic always-on unit (older images).
+    #   - raspi-config do_ssh 1 — the canonical toggle; covers whatever the
+    #     image's native mechanism is.
+    #   - boot-partition flags — sshswitch.service turns SSH back on at boot
+    #     if a bare `ssh` file exists on /boot or /boot/firmware.
+    # Deliberately AFTER the env-wipe-failed gate above: on a failed prep
+    # the device stays on and the owner may still need SSH to fix it. Runs
+    # even over an SSH session — pam_systemd puts interactive sessions in
+    # their own scope, so stopping the unit doesn't kill the invoking shell
+    # (and the poweroff below ends it anyway). Recipient re-enables via
+    # console per docs/recovery.md, same as a fresh flash.
+    echo -n "Disabling SSH for shipping... "
+    systemctl disable --now ssh.socket ssh.service 2>/dev/null || true
+    raspi-config nonint do_ssh 1 2>/dev/null || true
+    rm -f /boot/ssh /boot/ssh.txt /boot/firmware/ssh /boot/firmware/ssh.txt 2>/dev/null || true
+    echo -e "${GREEN}done${NC}"
+
     # Marker was written earlier (pre-stop) so shutdown-splash has already
     # painted the welcome screen by now. Just power off.
     echo "Gift mode: powering off."

--- a/scripts/reset-setup.sh
+++ b/scripts/reset-setup.sh
@@ -424,10 +424,11 @@ if [[ "$GIFT_MODE" == "true" ]]; then
     #   - ssh.socket — Raspberry Pi OS Bookworm SOCKET-ACTIVATES sshd: pid 1
     #     holds port 22 via ssh.socket and spawns sshd per-connection.
     #     Disabling ssh.service alone leaves the socket listening, so the
-    #     socket MUST be disabled — this is the load-bearing line on
+    #     socket MUST be disabled — this is the load-bearing unit on
     #     current images (hardware QA 2026-07-16 caught a service-only
-    #     disable leaving port 22 open after reprovision). Harmless no-op
-    #     on older service-activated images.
+    #     disable leaving port 22 open after reprovision). Disabled in a
+    #     SEPARATE call from ssh.service so a missing unit on an older
+    #     service-only image can't abort the other disable (/review).
     #   - ssh.service — the classic always-on unit (older images).
     #   - raspi-config do_ssh 1 — the canonical toggle; covers whatever the
     #     image's native mechanism is.
@@ -440,10 +441,36 @@ if [[ "$GIFT_MODE" == "true" ]]; then
     # (and the poweroff below ends it anyway). Recipient re-enables via
     # console per docs/recovery.md, same as a fresh flash.
     echo -n "Disabling SSH for shipping... "
-    systemctl disable --now ssh.socket ssh.service 2>/dev/null || true
+    systemctl disable --now ssh.socket 2>/dev/null || true
+    systemctl disable --now ssh.service 2>/dev/null || true
     raspi-config nonint do_ssh 1 2>/dev/null || true
     rm -f /boot/ssh /boot/ssh.txt /boot/firmware/ssh /boot/firmware/ssh.txt 2>/dev/null || true
     echo -e "${GREEN}done${NC}"
+
+    # #528 /review: SSH-off is a security GATE, so verify port 22 is
+    # actually closed rather than trusting the best-effort disables above
+    # (each is `|| true`, and socket-activation means the service state
+    # alone doesn't prove the port is shut). If sshd still listens, refuse
+    # to power off — same posture as the env-wipe failure below: shipping a
+    # device with SSH + default creds reachable on the recipient's network
+    # is exactly what this step exists to prevent. `ss` ships in iproute2
+    # (always present on Pi OS); if it can't run we can't verify, so warn
+    # and proceed rather than hard-block a gift on missing tooling.
+    if command -v ss >/dev/null 2>&1; then
+        # Extract the local port (last colon-field of the Local Address
+        # column) and match EXACTLY 22 — avoids false hits on :2222, :220…
+        if ss -H -ltn 2>/dev/null | awk '{n=split($4,a,":"); print a[n]}' | grep -qx 22; then
+            echo -e "${RED}========================================${NC}"
+            echo -e "${RED}  SSH still listening — do NOT ship this device${NC}"
+            echo -e "${RED}========================================${NC}"
+            echo -e "${RED}Port 22 is still open after disabling SSH. NOT powering off${NC}"
+            echo -e "${RED}so a device with SSH + default creds isn't shipped. Check:${NC}"
+            echo -e "${YELLOW}  systemctl status ssh.socket ssh.service${NC}"
+            exit 1
+        fi
+    else
+        echo -e "${YELLOW}Note: 'ss' unavailable — could not verify port 22 is closed.${NC}"
+    fi
 
     # Marker was written earlier (pre-stop) so shutdown-splash has already
     # painted the welcome screen by now. Just power off.

--- a/tests/test_reset_setup_sh.py
+++ b/tests/test_reset_setup_sh.py
@@ -146,13 +146,35 @@ class TestGiftMode:
         block = reset_sh_content[idx:elif_idx]
         # The socket is the load-bearing unit on current images — a
         # service-only disable ships a device with port 22 still open.
-        assert "ssh.socket" in block, "must disable ssh.socket (Bookworm socket-activation)"
-        assert "systemctl disable --now ssh.socket ssh.service" in block
+        # Disabled in a SEPARATE call from the service so a missing unit on
+        # an older image can't abort the other disable (/review).
+        assert "systemctl disable --now ssh.socket" in block, "must disable ssh.socket separately"
+        assert "systemctl disable --now ssh.service" in block, "must disable ssh.service separately"
         assert "raspi-config nonint do_ssh 1" in block
         assert "/boot/firmware/ssh" in block and "/boot/ssh" in block
         # And it must happen before the poweroff COMMAND (rfind: the word
         # also appears in comments earlier in the branch).
         assert block.find("systemctl disable --now ssh") < block.rfind("\n    poweroff")
+
+    def test_gift_mode_verifies_port_22_closed_as_gate(self, reset_sh_content):
+        """#528 /review: the SSH-off step is a security gate, not best-effort.
+        After disabling, it must verify port 22 is actually closed (the
+        disables are all `|| true`, and socket-activation means unit state
+        alone doesn't prove the port is shut) and refuse to power off if
+        sshd still listens — same abort-before-ship posture as the env-wipe
+        failure gate."""
+        idx = reset_sh_content.rfind('if [[ "$GIFT_MODE" == "true" ]]')
+        block = reset_sh_content[idx : reset_sh_content.find("elif", idx)]
+        assert "ss -H -ltn" in block, "must probe listening sockets to verify SSH is off"
+        # Exact port match, not a substring that would false-hit :2222 etc.
+        assert "grep -qx 22" in block
+        # The verify must sit AFTER the disables and gate the poweroff: the
+        # port-open branch exits before the poweroff command.
+        verify_idx = block.find("ss -H -ltn")
+        disable_idx = block.find("systemctl disable --now ssh.socket")
+        exit_idx = block.find("exit 1", verify_idx)
+        poweroff_idx = block.rfind("\n    poweroff")
+        assert disable_idx < verify_idx < exit_idx < poweroff_idx
 
     def test_gift_mode_ssh_disable_after_env_wipe_failure_gate(self, reset_sh_content):
         """#528: on a FAILED gift prep the script exits non-zero and the

--- a/tests/test_reset_setup_sh.py
+++ b/tests/test_reset_setup_sh.py
@@ -130,6 +130,42 @@ class TestGiftMode:
         block = reset_sh_content[idx:elif_idx]
         assert "poweroff" in block
 
+    def test_gift_mode_disables_ssh_before_poweroff(self, reset_sh_content):
+        """#528: gift mode must force SSH off before shipping — an owner who
+        ever enabled SSH (QA, recovery) would otherwise hand the recipient a
+        device with SSH + default creds listening on their network. Every
+        layer: the SOCKET (Bookworm socket-activates sshd — disabling only
+        ssh.service leaves port 22 open, caught by hardware QA 2026-07-16),
+        the classic service, raspi-config posture, and the boot-partition
+        re-enable flags (sshswitch re-enables SSH if a bare `ssh` file
+        exists on /boot or /boot/firmware)."""
+        # rfind: the end-of-script branch is the LAST $GIFT_MODE test in the
+        # file (the first one is the early marker-write block).
+        idx = reset_sh_content.rfind('if [[ "$GIFT_MODE" == "true" ]]')
+        elif_idx = reset_sh_content.find("elif", idx)
+        block = reset_sh_content[idx:elif_idx]
+        # The socket is the load-bearing unit on current images — a
+        # service-only disable ships a device with port 22 still open.
+        assert "ssh.socket" in block, "must disable ssh.socket (Bookworm socket-activation)"
+        assert "systemctl disable --now ssh.socket ssh.service" in block
+        assert "raspi-config nonint do_ssh 1" in block
+        assert "/boot/firmware/ssh" in block and "/boot/ssh" in block
+        # And it must happen before the poweroff COMMAND (rfind: the word
+        # also appears in comments earlier in the branch).
+        assert block.find("systemctl disable --now ssh") < block.rfind("\n    poweroff")
+
+    def test_gift_mode_ssh_disable_after_env_wipe_failure_gate(self, reset_sh_content):
+        """#528: on a FAILED gift prep the script exits non-zero and the
+        device stays on — the owner may need SSH to fix it. The SSH disable
+        must therefore sit AFTER the ENV_WIPE_FAILED fatal gate so the
+        failure path never locks the owner out."""
+        idx = reset_sh_content.rfind('if [[ "$GIFT_MODE" == "true" ]]')
+        block = reset_sh_content[idx : reset_sh_content.find("elif", idx)]
+        gate_idx = block.find('"$ENV_WIPE_FAILED" == "true"')
+        ssh_idx = block.find("systemctl disable --now ssh")
+        assert gate_idx != -1 and ssh_idx != -1
+        assert gate_idx < ssh_idx
+
     def test_gift_mode_marker_written_before_shutdown_service_stop(self, reset_sh_content):
         """CRITICAL ordering invariant: the .welcome-mode marker must be written
         BEFORE `systemctl stop litclock-shutdown.service`. That stop fires the
@@ -385,9 +421,7 @@ def test_defaults_include_weather_location_mode_and_ip_country():
     from pathlib import Path
 
     content = (Path(__file__).parent.parent / "scripts/reset-setup.sh").read_text()
-    assert "export WEATHER_LOCATION_MODE=auto" in content, (
-        "#337 A3: reset-setup.sh DEFAULTS must include MODE=auto"
-    )
+    assert "export WEATHER_LOCATION_MODE=auto" in content, "#337 A3: reset-setup.sh DEFAULTS must include MODE=auto"
     assert "export WEATHER_IP_COUNTRY=" in content, (
         "#337 A3: reset-setup.sh DEFAULTS must include WEATHER_IP_COUNTRY= (empty)"
     )
@@ -418,9 +452,7 @@ class TestPrivilegeHardening387:
     def test_gift_message_uses_system_python_not_venv(self, reset_sh_content):
         # Running the pi-writable venv interpreter as root is a pi->root vector;
         # the stdlib-only heredoc uses the root-owned system python instead.
-        assert "/usr/bin/python3 - " in reset_sh_content, (
-            "gift-message processing must use the system python3 (#387)"
-        )
+        assert "/usr/bin/python3 - " in reset_sh_content, "gift-message processing must use the system python3 (#387)"
         assert '"$INSTALL_DIR/venv/bin/python3" - "$GIFT_MESSAGE_FILE"' not in reset_sh_content, (
             "must NOT run the pi-writable venv interpreter as root (#387)"
         )
@@ -438,9 +470,7 @@ class TestPrivilegeHardening387:
             assert "reset-setup.sh" in body and "/usr/local/lib/litclock" in body, (
                 f"{name} must install reset-setup.sh root-owned to /usr/local/lib/litclock (#387)"
             )
-            assert "/usr/local/lib/litclock/lib" in body, (
-                f"{name} must install the root-owned lib/state.sh dir (#387)"
-            )
+            assert "/usr/local/lib/litclock/lib" in body, f"{name} must install the root-owned lib/state.sh dir (#387)"
             assert "lib/state.sh" in body, f"{name} must install state.sh alongside (#387)"
 
 
@@ -455,9 +485,7 @@ class TestFactoryResetStrictEnvWipe:
         assert "--strict-env-wipe) STRICT_ENV_WIPE=true" in reset_sh_content
 
     def test_strict_guard_precedes_wifi_wipe_and_reboot(self, reset_sh_content):
-        guard_idx = reset_sh_content.find(
-            '"$STRICT_ENV_WIPE" == "true" && "$ENV_WIPE_FAILED" == "true"'
-        )
+        guard_idx = reset_sh_content.find('"$STRICT_ENV_WIPE" == "true" && "$ENV_WIPE_FAILED" == "true"')
         assert guard_idx != -1, "strict-env-wipe fail-closed guard missing"
         # Guard aborts non-zero right after the check.
         exit_idx = reset_sh_content.find("exit 1", guard_idx)


### PR DESCRIPTION
## Problem

"Prepare for Gifting" wipes WiFi, resets config, and powers off — but never touched SSH. The shipped image has SSH off, so the common case is fine. But the whole point of gift mode is that the *owner* preps the device, and an owner who enabled SSH at any point (QA, recovery, tinkering) would hand the recipient a device with **SSH + the well-known default creds listening the moment it joins their home WiFi** — a classic default-cred exposure on someone else's network, on a device the recipient is by definition non-technical.

## Fix

Force SSH off in the gift path, across every way it can be on:

- **`ssh.socket`** — Raspberry Pi OS Bookworm socket-activates sshd (pid 1 holds port 22 and spawns sshd per-connection). Disabling `ssh.service` alone leaves the socket listening, so this is the load-bearing line on current images.
- **`ssh.service`** — the classic always-on unit (older images).
- **`raspi-config nonint do_ssh 1`** — the canonical toggle.
- **`/boot`/`/boot/firmware` flags** — `sshswitch` re-enables SSH at boot if a bare `ssh` file exists.

Placed after the env-wipe-failed gate: on a failed prep the device stays on and the owner may still need SSH to fix it.

## Testing

- Unit tests assert all four layers and correct ordering.
- **Hardware, on a real Pi:** a service-only disable left port 22 **open** after gift-mode + reprovision; adding the socket disable → port 22 **refused** end-to-end (clean A/B on the same device).

Recipient re-enables via console per `docs/recovery.md`, same as a fresh flash.
