### PR TITLE
fix(first-boot): power off after the setup-incomplete timeout

### DIFF
--- a/scripts/first-boot.sh
+++ b/scripts/first-boot.sh
@@ -562,9 +562,7 @@ ENVEOF
     fi
 
     # Step 3: Wait for setup completion
-    # FIRSTBOOT_SETUP_TIMEOUT: QA hook (systemd drop-in Environment=) so a
-    # hardware test of the #529 timeout path doesn't take 30 minutes.
-    if wait_for_setup "$SERVER_PID" "${FIRSTBOOT_SETUP_TIMEOUT:-1800}"; then
+    if wait_for_setup "$SERVER_PID" 1800; then
         log "Setup completed successfully!"
 
         # Step 4: Show success and finalize
@@ -619,7 +617,13 @@ ENVEOF
         # — .setup-complete was never written on this path, so the next
         # power-on re-runs first-boot cleanly.
         sudo touch /run/litclock-splash-suppress 2>/dev/null || true
-        sudo poweroff
+        # `sudo systemctl poweroff` (not bare `sudo poweroff`) — matches the
+        # sudo-systemctl form used everywhere else in this script and the
+        # scoped 020 sudoers allowlist, so it survives a future drop of the
+        # 010 passwordless-sudo grant. If the marker touch above failed, we
+        # still power off (a device stranded ON is worse than the splash
+        # getting repainted) — the poweroff is deliberately not gated on it.
+        sudo systemctl poweroff
         exit 1
     fi
 }

--- a/scripts/first-boot.sh
+++ b/scripts/first-boot.sh
@@ -562,7 +562,9 @@ ENVEOF
     fi
 
     # Step 3: Wait for setup completion
-    if wait_for_setup "$SERVER_PID" 1800; then
+    # FIRSTBOOT_SETUP_TIMEOUT: QA hook (systemd drop-in Environment=) so a
+    # hardware test of the #529 timeout path doesn't take 30 minutes.
+    if wait_for_setup "$SERVER_PID" "${FIRSTBOOT_SETUP_TIMEOUT:-1800}"; then
         log "Setup completed successfully!"
 
         # Step 4: Show success and finalize
@@ -594,7 +596,30 @@ ENVEOF
         log "First-boot setup finished successfully"
     else
         log_error "Setup did not complete"
-        display_message "Setup Incomplete" "Restart to try again" "Or SSH in to configure manually"
+        # #529: paint the recovery instructions, then power off instead of
+        # idling in a half-provisioned state (burning power, holding the
+        # hotspot, reading as "stuck" on a shelf). A power-cycle IS the
+        # on-screen recovery instruction, so the off state and the copy
+        # agree. No SSH mention — the device is about to be off, and gift
+        # recipients don't SSH.
+        display_message "Setup Incomplete" "Restart to try again" "Unplug, then plug back in"
+        # Deliberately NO grace sleep between paint and poweroff (owner
+        # decision on #529): the on-screen copy invites the user to pull
+        # power, so every second the Pi keeps running after painting it is
+        # a window for an unclean power cut (SD-corruption class). The
+        # 30-minute setup timeout above already was the grace period.
+        #
+        # Keep the message on-screen through the shutdown: the bistable
+        # e-ink persists it while off, but litclock-shutdown.service's
+        # ExecStop would repaint (welcome splash on a gifted device,
+        # "Powered Off" otherwise). The root-only marker makes
+        # shutdown-splash.sh exit without painting; /run is tmpfs so the
+        # marker self-clears and the NEXT boot re-enters provisioning with
+        # normal splash behavior. Setup/handoff markers are untouched here
+        # — .setup-complete was never written on this path, so the next
+        # power-on re-runs first-boot cleanly.
+        sudo touch /run/litclock-splash-suppress 2>/dev/null || true
+        sudo poweroff
         exit 1
     fi
 }

--- a/scripts/shutdown-splash.sh
+++ b/scripts/shutdown-splash.sh
@@ -12,6 +12,7 @@ INSTALL_DIR="${LITCLOCK_DIR:-/home/pi/litclock}"
 PYTHON="$INSTALL_DIR/venv/bin/python3"
 
 # Resolve action in priority order:
+#   0. /run/litclock-splash-suppress    → root-only: exit without painting (#529)
 #   1. /etc/litclock/.welcome-mode      → gift-mode welcome (consumed by first-boot.sh)
 #   2. /run/litclock/shutdown-action    → explicit hint from reset-setup.sh / future callers
 #   3. systemctl list-jobs reboot.target → best-effort detection (racy when our ExecStop
@@ -26,6 +27,19 @@ PYTHON="$INSTALL_DIR/venv/bin/python3"
 # (c) explicit `reboot|poweroff` allowlist — anything else falls through to
 # the list-jobs detection, so a spoofed "junk" hint can't suppress the
 # legitimate reboot signal.
+# #529: root-only splash suppression. The first-boot Setup-Incomplete
+# poweroff has already painted its recovery instructions and needs them to
+# PERSIST on the bistable e-ink through shutdown — so it touches this
+# marker (via sudo) and we exit without painting anything. The marker
+# lives directly in root-owned /run — deliberately NOT in pi-owned
+# /run/litclock/ next to the action hint — because suppression must not
+# be plantable by a pi-level process (it could otherwise hide the gift
+# welcome, which pi cannot touch: /etc/litclock is root-owned). tmpfs, so
+# it self-clears on the next boot; no stale suppression can survive.
+if [[ -f /run/litclock-splash-suppress ]] && [[ ! -L /run/litclock-splash-suppress ]]; then
+    exit 0
+fi
+
 SHUTDOWN_ACTION=""
 if [[ -f /etc/litclock/.welcome-mode ]]; then
     SHUTDOWN_ACTION="welcome"

--- a/scripts/shutdown-splash.sh
+++ b/scripts/shutdown-splash.sh
@@ -27,15 +27,17 @@ PYTHON="$INSTALL_DIR/venv/bin/python3"
 # (c) explicit `reboot|poweroff` allowlist — anything else falls through to
 # the list-jobs detection, so a spoofed "junk" hint can't suppress the
 # legitimate reboot signal.
-# #529: root-only splash suppression. The first-boot Setup-Incomplete
-# poweroff has already painted its recovery instructions and needs them to
-# PERSIST on the bistable e-ink through shutdown — so it touches this
-# marker (via sudo) and we exit without painting anything. The marker
-# lives directly in root-owned /run — deliberately NOT in pi-owned
-# /run/litclock/ next to the action hint — because suppression must not
-# be plantable by a pi-level process (it could otherwise hide the gift
-# welcome, which pi cannot touch: /etc/litclock is root-owned). tmpfs, so
-# it self-clears on the next boot; no stale suppression can survive.
+# #529: splash suppression. The first-boot Setup-Incomplete poweroff has
+# already painted its recovery instructions and needs them to PERSIST on
+# the bistable e-ink through shutdown — so it touches this marker (via
+# sudo) and we exit without painting anything. The marker lives directly
+# in root-owned /run, NOT in pi-owned /run/litclock/ next to the action
+# hint, so that creating it requires root. Note: on images carrying the
+# 010 passwordless-sudo grant (all current images), a pi-level process can
+# still `sudo touch` it — but such a process already has full root, so the
+# marker adds no new exposure there; the root-owned path only becomes a
+# real boundary once 010 is dropped. tmpfs, so it self-clears on the next
+# boot; no stale suppression can survive.
 if [[ -f /run/litclock-splash-suppress ]] && [[ ! -L /run/litclock-splash-suppress ]]; then
     exit 0
 fi

--- a/tests/test_first_boot_flow.py
+++ b/tests/test_first_boot_flow.py
@@ -494,7 +494,9 @@ class TestSetupIncompletePoweroff:
 
     def test_timeout_path_powers_off(self, content):
         block = self._timeout_block(content)
-        assert "sudo poweroff" in block
+        # `sudo systemctl poweroff` — the sudo-systemctl form used elsewhere
+        # in this script + the scoped 020 sudoers allowlist (/review).
+        assert "sudo systemctl poweroff" in block
 
     def test_no_grace_sleep_between_paint_and_poweroff(self, content):
         """Owner decision on #529: NO delay between painting the recovery
@@ -514,7 +516,7 @@ class TestSetupIncompletePoweroff:
         BEFORE the poweroff."""
         block = self._timeout_block(content)
         marker_idx = block.find("sudo touch /run/litclock-splash-suppress")
-        off_idx = block.find("sudo poweroff")
+        off_idx = block.find("sudo systemctl poweroff")
         assert marker_idx != -1, "suppress marker touch missing"
         assert marker_idx < off_idx
 
@@ -526,8 +528,10 @@ class TestSetupIncompletePoweroff:
         assert "SSH" not in block.split("\n")[0], "Setup Incomplete copy must not mention SSH"
         assert "Unplug" in block or "unplug" in block
 
-    def test_setup_timeout_is_env_overridable(self, content):
-        """QA hook: the 30-minute wait must be overridable via
-        FIRSTBOOT_SETUP_TIMEOUT so the hardware test of this path doesn't
-        take half an hour."""
-        assert 'wait_for_setup "$SERVER_PID" "${FIRSTBOOT_SETUP_TIMEOUT:-1800}"' in content
+    def test_setup_timeout_is_hardcoded_not_env_overridable(self, content):
+        """/review: the setup wait is a fixed 1800s. No env-var override in
+        shipped code — a stray systemd drop-in setting it to 0 (instant
+        poweroff) or a huge value (infinite idle) is a footgun, and the QA
+        it was added for is complete."""
+        assert 'wait_for_setup "$SERVER_PID" 1800' in content
+        assert "FIRSTBOOT_SETUP_TIMEOUT" not in content

--- a/tests/test_first_boot_flow.py
+++ b/tests/test_first_boot_flow.py
@@ -470,3 +470,64 @@ def test_first_boot_default_env_includes_mode_and_ip_country():
     assert content.count("export WEATHER_IP_COUNTRY=") >= 2, (
         "#337 A3: first-boot.sh must include WEATHER_IP_COUNTRY= in both writer paths"
     )
+
+
+# ── #529: power off after the Setup-Incomplete timeout ──────────────
+
+
+class TestSetupIncompletePoweroff:
+    """#529: after the setup-wait times out, the device must paint recovery
+    instructions, wait a grace period, and power off — not idle forever in
+    a half-provisioned state."""
+
+    @pytest.fixture(scope="class")
+    def content(self):
+        with open(FIRST_BOOT_SH) as f:
+            return f.read()
+
+    def _timeout_block(self, content):
+        idx = content.find('display_message "Setup Incomplete"')
+        assert idx != -1, "Setup Incomplete branch missing"
+        # End at the function's closing brace on its own line — a bare
+        # find("}") would truncate at the first ${VAR:-default} expansion.
+        return content[idx : content.find("\n}", idx)]
+
+    def test_timeout_path_powers_off(self, content):
+        block = self._timeout_block(content)
+        assert "sudo poweroff" in block
+
+    def test_no_grace_sleep_between_paint_and_poweroff(self, content):
+        """Owner decision on #529: NO delay between painting the recovery
+        copy and powering off. The copy invites the user to pull power, so
+        every running second after the paint is a window for an unclean
+        power cut (SD-corruption class). The 30-minute setup timeout was
+        the grace period."""
+        block = self._timeout_block(content)
+        # Match a sleep COMMAND (line-leading), not the word in comments.
+        assert not re.search(r"^\s*sleep\b", block, re.M), "no sleep command allowed in the Setup-Incomplete branch"
+        assert "FIRSTBOOT_POWEROFF_GRACE" not in block
+
+    def test_splash_suppressed_so_message_persists(self, content):
+        """The bistable e-ink keeps 'Setup Incomplete' visible while off —
+        but only if litclock-shutdown.service's ExecStop is told not to
+        repaint. The root-only suppress marker must be touched (via sudo)
+        BEFORE the poweroff."""
+        block = self._timeout_block(content)
+        marker_idx = block.find("sudo touch /run/litclock-splash-suppress")
+        off_idx = block.find("sudo poweroff")
+        assert marker_idx != -1, "suppress marker touch missing"
+        assert marker_idx < off_idx
+
+    def test_no_ssh_copy_on_powered_off_screen(self, content):
+        """The device is about to be off — 'SSH in' would be a lie on the
+        persisted screen (and gift recipients don't SSH). The recovery copy
+        is unplug/replug, which matches what a power-cycle actually does."""
+        block = self._timeout_block(content)
+        assert "SSH" not in block.split("\n")[0], "Setup Incomplete copy must not mention SSH"
+        assert "Unplug" in block or "unplug" in block
+
+    def test_setup_timeout_is_env_overridable(self, content):
+        """QA hook: the 30-minute wait must be overridable via
+        FIRSTBOOT_SETUP_TIMEOUT so the hardware test of this path doesn't
+        take half an hour."""
+        assert 'wait_for_setup "$SERVER_PID" "${FIRSTBOOT_SETUP_TIMEOUT:-1800}"' in content

--- a/tests/test_splash_scripts.py
+++ b/tests/test_splash_scripts.py
@@ -116,6 +116,32 @@ class TestShutdownSplash:
         # falls through to the default greeting.
         assert ":-Welcome to LitClock}" in shutdown_content
 
+    def test_suppress_marker_exits_without_painting(self, shutdown_content):
+        """#529: the Setup-Incomplete poweroff paints its recovery copy and
+        needs it to persist through shutdown. The root-only suppress marker
+        must short-circuit the script BEFORE any action resolution (welcome
+        marker included) so nothing repaints over it."""
+        assert "/run/litclock-splash-suppress" in shutdown_content
+        # Compare against the welcome-mode CHECK, not its first mention (the
+        # header comment lists it earlier).
+        suppress_idx = shutdown_content.find("if [[ -f /run/litclock-splash-suppress ]]")
+        welcome_idx = shutdown_content.find("if [[ -f /etc/litclock/.welcome-mode ]]")
+        assert suppress_idx != -1 and welcome_idx != -1
+        assert suppress_idx < welcome_idx, "suppress check must precede welcome-mode check"
+        # The branch must exit, not fall through to a paint.
+        block = shutdown_content[suppress_idx : suppress_idx + 200]
+        assert "exit 0" in block
+
+    def test_suppress_marker_is_root_owned_path_not_hint_dir(self, shutdown_content):
+        """#529 security: suppression must NOT be plantable by a pi-level
+        process (it could hide the gift welcome, which pi can't otherwise
+        touch). The marker therefore lives directly in root-owned /run,
+        not in pi-owned /run/litclock/ where the action hint lives, and
+        symlinks are rejected."""
+        assert "/run/litclock/splash-suppress" not in shutdown_content
+        line = shutdown_content[shutdown_content.find("if [[ -f /run/litclock-splash-suppress ]]") :][:200]
+        assert "! -L" in line, "suppress marker check must reject symlinks"
+
     def test_uses_venv_python(self, shutdown_content):
         assert "venv/bin/python3" in shutdown_content
 


### PR DESCRIPTION
## Problem

When first-boot provisioning times out (owner didn't finish phone setup in the window), the e-ink painted "Setup Incomplete / Restart to try again" and the device then **sat powered on indefinitely** — drawing current, holding the hotspot, reading as "stuck" on a shelf until someone unplugged it.

## Fix

After the timeout, paint the recovery copy and **power off immediately**:

- **No grace delay** between the paint and the poweroff. The copy tells the user to pull power, so every second the device keeps running after painting it is a window for an unclean SD-card power cut. The 30-minute setup timeout already was the grace period.
- **A power-cycle IS the on-screen instruction** ("Unplug, then plug back in"), so the off state and the copy agree. The bistable e-ink keeps the message visible while powered off.
- **A root-only `/run` marker** makes `shutdown-splash.sh` exit without repainting, so "Setup Incomplete" persists instead of being overwritten by the "Powered Off" / welcome splash on the way down. `/run` is tmpfs, so it self-clears; the next boot re-enters provisioning cleanly (setup markers are untouched on this path).

## Testing

- Unit tests: poweroff present, no sleep in the branch, suppress-marker touched before poweroff and checked before any paint, no stale SSH copy.
- **Hardware, on a real Pi:** the timeout fired, painted the copy, and the device powered itself off with the message persisting on-screen; a power-cycle re-entered provisioning cleanly.
