### PR TITLE
fix(image-gen): size the word-char probe window to one UTF-8 char

### DIFF
--- a/image-gen/quote_to_image.php
+++ b/image-gen/quote_to_image.php
@@ -230,10 +230,17 @@ function TurnQuoteIntoImage($time, $quote, $timestring, $title, $author, $imagen
     // whole UTF-8 chars.
     $qlen = strlen($quote);
     $word_char_at = function ($i) use ($quote, $qlen) {
-        // Is a Unicode letter or number the char starting at byte $i? (4-byte
-        // window always spans the full first char; the anchored match ignores
-        // any trailing partial bytes of the next char.)
-        return $i < $qlen && preg_match('/^[\p{L}\p{N}]/u', substr($quote, $i, 4)) === 1;
+        // Is a Unicode letter or number the char starting at byte $i? The window
+        // is exactly one UTF-8 char, sized from its lead byte. A fixed 4-byte
+        // window can slice the NEXT char mid-sequence, and PCRE /u validates the
+        // WHOLE subject before matching — an invalid tail returns false
+        // (PREG_BAD_UTF8_ERROR) even when the first char IS a letter (#19).
+        if ($i >= $qlen) {
+            return false;
+        }
+        $b = ord($quote[$i]);
+        $len = ($b < 0x80) ? 1 : (($b < 0xE0) ? 2 : (($b < 0xF0) ? 3 : 4));
+        return preg_match('/^[\p{L}\p{N}]/u', substr($quote, $i, $len)) === 1;
     };
     if ($word_char_at($ts_char_end)) {
         // case 1 — mid-word: keep the whole word bold


### PR DESCRIPTION
The bold-boundary logic checks whether the character at a byte offset is a letter/number by running an anchored `\p{L}\p{N}` match over a fixed 4-byte window. PCRE with `/u` validates the whole subject as UTF-8 before matching, so a window that slices the *next* character mid-sequence (e.g. `é` followed by `—`, or CJK followed by CJK) fails validation and reports "not a word char" even when the first character is a letter. The code comment claiming trailing partial bytes are ignored was incorrect.

Fix: size the window from the lead byte so it always contains exactly one complete character (same byte-length idiom the scan loop below it already uses; no new dependency).

This is dormant on the current English corpus and matters for localized quotes (#19), where a mid-word timestring match followed by an accented character kept the bold truncated mid-word instead of extending to the whole word as the #503/#504 rules intend.

Verification:
- Full corpus regenerated before/after the patch: all 4,809 quote PNGs and 4,809 metadata PNGs are byte-identical (manifest differs only in `generator_hash`/`created_at`). No images release needed.
- `ts_char_end` computed with old vs new logic through the exact production code path: identical on all 4,809 rows, zero `NOSTRING`.
- 4,304-case fuzz battery (accents, Greek, Cyrillic, CJK, emoji, NBSP, end-of-string and past-end windows) matches the intended one-char semantics; 19-case unit table covers the 6 quirk shapes.
- `php -l`, ruff, 2,700 Python tests, 168 JS tests all pass.

Note for the next corpus regen: the recorded `generator_hash` changes, so the #299 skip rule will re-render everything once; outputs are proven byte-identical so that pass is a no-op on disk content.
