### PR TITLE
docs: retire the one-line installer

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -23,7 +23,7 @@ What should happen instead.
 - **Pi model**: (e.g., Pi Zero 2 W)
 - **Display**: (e.g., Waveshare 7.5" V2)
 - **OS**: (output of `cat /etc/os-release | head -2`)
-- **Installation method**: (DIY install / pre-configured SD card)
+- **Installation method**: (flashed LitClock image / pre-configured SD card / other)
 
 ## Logs / diagnostics
 

--- a/.gitignore
+++ b/.gitignore
@@ -69,11 +69,11 @@ pi-gen/work/
 /images/
 !images/.installed-version
 
-# Runtime-renderer validation marker. Written ONLY by
-# `tools/validate_measurement.py check --stamp` on the machine whose FreeType
-# it actually verified, and read by literary_clock.py before honouring
-# LITCLOCK_RUNTIME_RENDER. Machine-specific state: if it were committed, every
-# checkout would claim a validation it never ran.
+# Renderer-validation marker: records the local font stack a measurement run
+# was verified against. Machine-specific by nature - committing it would let
+# every checkout claim a validation it never ran. The tooling that writes and
+# reads it is not in this repo yet; this rule is here so a stray marker from a
+# development checkout can never be committed by accident.
 .runtime-render-validated
 
 # Scratch dirs and locks used by scripts/download_images.sh (transient).

--- a/.gitignore
+++ b/.gitignore
@@ -69,6 +69,13 @@ pi-gen/work/
 /images/
 !images/.installed-version
 
+# Runtime-renderer validation marker. Written ONLY by
+# `tools/validate_measurement.py check --stamp` on the machine whose FreeType
+# it actually verified, and read by literary_clock.py before honouring
+# LITCLOCK_RUNTIME_RENDER. Machine-specific state: if it were committed, every
+# checkout would claim a validation it never ran.
+.runtime-render-validated
+
 # Scratch dirs and locks used by scripts/download_images.sh (transient).
 .litclock-images-staging.*
 .litclock-images.lock

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -287,8 +287,8 @@ The 5 apt-provisioned names (`gpiozero`, `lgpio`, `pigpio`, `spidev`,
 `colorzero`) are listed in `requirements.in` so the resolver has the
 full constraint graph AND the lockfile is self-documenting. The install
 paths (`scripts/update.sh`, `pi-gen/stage3/01-setup-app/00-run.sh`)
-filter these names out of
-the generated lock before pip-install via `requirements-apt.txt` —
+filter these names out of the generated lock before pip-install via
+`requirements-apt.txt` —
 they come from apt at runtime via `--system-site-packages` (issue #214).
 
 **Why not eager `--upgrade-strategy`?** PR #322 narrowed `update.sh` to

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -286,8 +286,8 @@ still letting `pip-compile --upgrade` pick newer compatible releases.
 The 5 apt-provisioned names (`gpiozero`, `lgpio`, `pigpio`, `spidev`,
 `colorzero`) are listed in `requirements.in` so the resolver has the
 full constraint graph AND the lockfile is self-documenting. The install
-paths (`scripts/install.sh`, `scripts/update.sh`,
-`pi-gen/stage3/01-setup-app/00-run.sh`) filter these names out of
+paths (`scripts/update.sh`, `pi-gen/stage3/01-setup-app/00-run.sh`)
+filter these names out of
 the generated lock before pip-install via `requirements-apt.txt` —
 they come from apt at runtime via `--system-site-packages` (issue #214).
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -130,10 +130,15 @@ cd litclock
 python3 -m venv --system-site-packages venv
 source venv/bin/activate
 
-# Install dependencies. requirements-apt.txt lists packages that come from
-# apt on the Pi (don't pip-install them into the venv — it either fails
-# to compile on a gcc-less image, or shadows the apt version with a binary
-# that gpiozero may then pick as its pin_factory backend — see #214).
+# Install dependencies. On a dev box this plain install is what you want —
+# pip's copies of the GPIO libs let the tests import them.
+#
+# On the Pi it is NOT. requirements-apt.txt lists packages that come from
+# apt there, and pip-installing them into the venv either fails to compile
+# on a gcc-less image, or shadows the apt version with a binary that
+# gpiozero may then pick as its pin_factory backend (see #214). Every
+# install path filters those names out first; the README shows the filter
+# if you are working on the device.
 pip install -r requirements.txt
 ```
 

--- a/README.md
+++ b/README.md
@@ -50,17 +50,45 @@ Full details in **[Hardware Assembly](docs/hardware-assembly.md)**.
 That's it — no config files to edit, no SSH to set up. Everything else happens from your phone after power-on.
 
 <details>
-<summary><b>Installing on an existing Raspberry Pi OS instead</b> (terminal required)</summary>
+<summary><b>Running your own code on the clock</b> (terminal required)</summary>
 
-On a fresh Raspberry Pi OS Lite install, SSH in (or connect a keyboard) and run:
+> **The one-line `curl … | bash` installer has been retired.** It had to make
+> system-level decisions — SPI overlays, sudo rules, group membership — on a
+> machine whose settings belong to you, which made it impossible to test
+> honestly. It had also drifted from the image build: it never writes the
+> `dtoverlay=spi0-1cs` line the e-Paper HAT needs, which the image does.
+> `scripts/install.sh` is still in the tree for reference, but it is
+> unmaintained and untested — please don't run it.
+
+The flashed image contains a git checkout at `/home/pi/litclock`, so it doubles
+as a development environment:
+
+1. Flash the released image and finish WiFi setup
+2. SSH in — **SSH ships disabled**, see [Recovering a LitClock](docs/recovery.md) for how to turn it on
+3. Fetch your fork and check out your branch:
 
 ```bash
-curl -sSL https://raw.githubusercontent.com/kapoorankush/litclock/master/scripts/install.sh | bash
+cd /home/pi/litclock
+git remote add fork https://github.com/<you>/litclock.git
+git fetch --depth 1 fork <your-branch>
+git checkout -b <your-branch> FETCH_HEAD
+sudo systemctl restart litclock.service litclock-control.service
 ```
 
-The installer sets up system dependencies, the BCM2835 driver, SPI, NTP sync, the Python venv, all systemd services, and downloads the quote-image set (~130 MB — needs network; the clock falls back to a time-only display if the download fails). It also detects Pi Zero W hardware and offers the [WiFi stability fixes](#wifi-stability-pi-zero-w--zero-2-w). Reboot when it finishes — from there the flow matches the flashed image.
+`litclock.service` paints the panel; `litclock-control.service` serves the
+control app. Restart both, or changes to the app will look like they never
+applied. If your branch changes `requirements.txt`, also run
+`./venv/bin/pip install -r requirements.txt` — the checkout does not rebuild
+the venv.
 
-The installer and updater are for existing OS installs only; for a fresh SD card, the downloadable image above is the way.
+> **Turn off the auto-updater first.** `litclock-update.timer` ships enabled and
+> fires on its own — Sunday 03:00, with up to seven days of jitter. It resolves
+> the latest release tag and `git reset --hard`s onto it, so it will silently
+> discard your branch while you are not looking:
+>
+> ```bash
+> sudo systemctl disable --now litclock-update.timer
+> ```
 </details>
 
 ### 3. Print and assemble the case
@@ -322,13 +350,13 @@ cd /home/pi/litclock && ./scripts/runtheclock.sh
 
 ### WiFi Stability (Pi Zero W / Zero 2 W)
 
-The Raspberry Pi Zero W and Zero 2 W have a known WiFi stability issue with the BCM43430 chip that can cause the system to hang and become unreachable. The flashed image applies mitigations out of the box, and the DIY installer detects the hardware and offers them:
+The Raspberry Pi Zero W and Zero 2 W have a known WiFi stability issue with the Broadcom WiFi chip that can cause the system to hang and become unreachable. The flashed image applies these mitigations out of the box:
 
 - **Driver parameters**: Disables roaming and problematic power features
 - **Power management**: Disables WiFi power saving
 - **Watchdog**: Automatically reboots if WiFi becomes unreachable
 
-If you experience WiFi disconnections or system hangs, re-run the installer to re-apply the fixes.
+If you experience WiFi disconnections or system hangs, confirm all three mitigations are in place: `cat /etc/modprobe.d/brcmfmac.conf`, `iwconfig wlan0 | grep "Power Management"` (should read `off`), and `systemctl status wifi-watchdog.timer`.
 
 ### Going deeper
 

--- a/README.md
+++ b/README.md
@@ -62,20 +62,36 @@ That's it — no config files to edit, no SSH to set up. Everything else happens
 > set up a clock, and nobody tests it end to end on real hardware. Please
 > don't run it.
 
-> **Turn off both auto-recovery paths before you start**, or the clock will
-> silently discard your branch while you are not looking. Two separate units
-> `git reset --hard` the checkout:
+> **Turn the clock's self-repair off as soon as you have a shell**, before you
+> check anything out. Left on, it will reboot the Pi under you and eventually
+> throw your branch away. Two units matter:
 >
 > - `litclock-update.timer` ships enabled and fires Sunday 03:00, with up to
->   seven days of jitter. It resolves the latest release tag and resets onto it.
-> - `litclock-bootcheck.timer` is the one people miss. If the clock boots and
->   never paints a quote — the normal state of work in progress — it starts
->   `litclock-update.service` **directly** in rollback mode, about 12 minutes
->   after boot and every 5 minutes after that. Disabling the update *timer*
->   does not stop it, because it never goes through the timer.
+>   seven days of jitter. It resolves the latest release tag and
+>   `git reset --hard`s onto it.
+> - `litclock-bootcheck.timer` is the one people miss. Starting ~12 minutes
+>   after boot and every 5 minutes after that, it checks whether the clock has
+>   painted a quote — and a branch that doesn't paint is indistinguishable from
+>   a broken clock. The first two failed boots each trigger
+>   `sudo systemctl reboot`, so your SSH session dies with no explanation. On
+>   the third it starts `litclock-update.service` in rollback mode, which
+>   resets the checkout to the last known-good SHA.
 >
 > ```bash
 > sudo systemctl disable --now litclock-update.timer litclock-bootcheck.timer
+> sudo systemctl mask litclock-update.service
+> ```
+>
+> Masking the service, and not just disabling its timer, also closes the third
+> route to the same `git reset --hard`: the **Apply update** button in the
+> control app, which starts the service directly.
+>
+> Put it back when you're done, or you'll hand over a clock with no recovery
+> net — this is what stops a bad update bricking a device with no keyboard:
+>
+> ```bash
+> sudo systemctl unmask litclock-update.service
+> sudo systemctl enable --now litclock-update.timer litclock-bootcheck.timer
 > ```
 
 The flashed image contains a git checkout at `/home/pi/litclock`, so it doubles
@@ -104,9 +120,11 @@ the apt copy. Every install path filters them out first, so do the same:
 
 ```bash
 cd /home/pi/litclock
+REQ=$(mktemp)
 EXCLUDE_RE=$(grep -vE '^[[:space:]]*(#|$)' requirements-apt.txt | sed 's/\./\\./g' | paste -sd'|')
-grep -vE "^(${EXCLUDE_RE})==" requirements.txt > /tmp/requirements-dev.txt
-./venv/bin/pip install --upgrade -r /tmp/requirements-dev.txt
+grep -vE "^(${EXCLUDE_RE})==" requirements.txt > "$REQ"
+./venv/bin/pip install --upgrade -r "$REQ"
+rm -f "$REQ"
 ```
 
 </details>

--- a/README.md
+++ b/README.md
@@ -56,9 +56,27 @@ That's it — no config files to edit, no SSH to set up. Everything else happens
 > system-level decisions — SPI overlays, sudo rules, group membership — on a
 > machine whose settings belong to you, which made it impossible to test
 > honestly. It had also drifted from the image build: it never writes the
-> `dtoverlay=spi0-1cs` line the e-Paper HAT needs, which the image does.
-> `scripts/install.sh` is still in the tree for reference, but it is
-> unmaintained and untested — please don't run it.
+> `dtoverlay=spi0-1cs` line the image does, which pins the display to CE0.
+> `scripts/install.sh` is still in the tree, and CI still holds it in sync with
+> the image build so the two don't diverge — but it is unsupported as a way to
+> set up a clock, and nobody tests it end to end on real hardware. Please
+> don't run it.
+
+> **Turn off both auto-recovery paths before you start**, or the clock will
+> silently discard your branch while you are not looking. Two separate units
+> `git reset --hard` the checkout:
+>
+> - `litclock-update.timer` ships enabled and fires Sunday 03:00, with up to
+>   seven days of jitter. It resolves the latest release tag and resets onto it.
+> - `litclock-bootcheck.timer` is the one people miss. If the clock boots and
+>   never paints a quote — the normal state of work in progress — it starts
+>   `litclock-update.service` **directly** in rollback mode, about 12 minutes
+>   after boot and every 5 minutes after that. Disabling the update *timer*
+>   does not stop it, because it never goes through the timer.
+>
+> ```bash
+> sudo systemctl disable --now litclock-update.timer litclock-bootcheck.timer
+> ```
 
 The flashed image contains a git checkout at `/home/pi/litclock`, so it doubles
 as a development environment:
@@ -77,18 +95,20 @@ sudo systemctl restart litclock.service litclock-control.service
 
 `litclock.service` paints the panel; `litclock-control.service` serves the
 control app. Restart both, or changes to the app will look like they never
-applied. If your branch changes `requirements.txt`, also run
-`./venv/bin/pip install -r requirements.txt` — the checkout does not rebuild
-the venv.
+applied. The checkout does not rebuild the venv, so if your branch changes
+`requirements.txt` you have to reinstall — but **not** with a plain
+`pip install -r requirements.txt`. The packages named in `requirements-apt.txt`
+come from apt on the image; pip would try to build them from source, which
+needs a compiler the image does not have, and a successful build would shadow
+the apt copy. Every install path filters them out first, so do the same:
 
-> **Turn off the auto-updater first.** `litclock-update.timer` ships enabled and
-> fires on its own — Sunday 03:00, with up to seven days of jitter. It resolves
-> the latest release tag and `git reset --hard`s onto it, so it will silently
-> discard your branch while you are not looking:
->
-> ```bash
-> sudo systemctl disable --now litclock-update.timer
-> ```
+```bash
+cd /home/pi/litclock
+EXCLUDE_RE=$(grep -vE '^[[:space:]]*(#|$)' requirements-apt.txt | sed 's/\./\\./g' | paste -sd'|')
+grep -vE "^(${EXCLUDE_RE})==" requirements.txt > /tmp/requirements-dev.txt
+./venv/bin/pip install --upgrade -r /tmp/requirements-dev.txt
+```
+
 </details>
 
 ### 3. Print and assemble the case

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ Every LitClock serves a small web app on your home network at **`http://litclock
 
 Weather works out of the box — no signup, no API key. The clock uses [Open-Meteo](https://open-meteo.com) as its default forecast provider, and location, timezone, and units are auto-detected during setup. Day-to-day changes are made in the control app's **Settings** tab. That's the whole configuration.
 
-Under the hood, settings live in `/home/pi/litclock/env.sh`. You only need to touch this file on a DIY install or for the advanced options below:
+Under the hood, settings live in `/home/pi/litclock/env.sh`. You only need to touch this file for the advanced options below:
 
 ```bash
 # Weather location (written by setup / the control app; override here if you want)
@@ -196,7 +196,7 @@ The OpenWeatherMap free tier allows 1,000 calls per day; the clock caches foreca
 <details>
 <summary><b>Advanced: overriding location coordinates</b></summary>
 
-The control app's Location setting handles geocoding for most users (it accepts city names, postal codes, and has an Advanced panel for raw coordinates). If you'd rather edit the file directly — for example on a DIY install — set `WEATHER_LATITUDE` and `WEATHER_LONGITUDE` in `env.sh`.
+The control app's Location setting handles geocoding for most users (it accepts city names, postal codes, and has an Advanced panel for raw coordinates). If you'd rather edit the file directly over SSH, set `WEATHER_LATITUDE` and `WEATHER_LONGITUDE` in `env.sh`.
 
 Finding coordinates:
 

--- a/docs/building-image.md
+++ b/docs/building-image.md
@@ -84,7 +84,7 @@ LITCLOCK_REF=v0.218.0 LITCLOCK_VERSION=0.218.0 ./pi-gen/build.sh
 
 ## What the Image Includes
 
-The custom pi-gen stage (`pi-gen/stage3/`) replicates everything `scripts/install.sh` does:
+The custom pi-gen stage (`pi-gen/stage3/`) provisions everything a working clock needs:
 
 1. **System packages** — Python, image libraries, fonts, wireless tools, qrencode
 2. **BCM2835 library** — compiled from source for GPIO/SPI access

--- a/docs/building-image.md
+++ b/docs/building-image.md
@@ -128,7 +128,7 @@ Insert the SD card into a Pi Zero 2W and power on, then check:
 
 1. **Splash screen** — "LitClock / Starting..." appears on the e-ink display
 2. **WiFi hotspot** — "LitClock-Setup" network becomes available
-3. **Phone setup** — connect to the hotspot, scan the QR code on the display, complete the setup form (location, timezone, API key)
+3. **Phone setup** — connect to the hotspot, scan the QR code on the display, and submit the setup form (WiFi network and password only — location, timezone and units are detected automatically after the Pi joins your network)
 4. **Clock starts** — after setup, the display updates every minute with a literary quote
 5. **Version metadata** — SSH in and verify:
    ```bash

--- a/docs/hardware-assembly.md
+++ b/docs/hardware-assembly.md
@@ -14,11 +14,11 @@
 
 ## Assembly
 
-1. **Flash the SD card** with Raspberry Pi OS using [Raspberry Pi Imager](https://www.raspberrypi.com/software/)
+1. **Flash the SD card** with the latest LitClock image using [Raspberry Pi Imager](https://www.raspberrypi.com/software/) — see [Flash the SD card](../README.md#2-flash-the-sd-card)
 2. **Connect the HAT** to the Pi's 40-pin GPIO header — align pin 1 and press firmly
 3. **Connect the e-Paper display** to the HAT via the flat ribbon cable — lift the connector latch, slide the cable in (contacts facing down), and close the latch
 4. **Insert the SD card** into the Pi
-5. **Enable SPI** — after first boot, run `sudo raspi-config` → Interface Options → SPI → Enable (the installer does this automatically if you use `install.sh`)
+5. **SPI is already enabled** by the image — if the display stays blank, check that `/dev/spidev0.0` exists and see [Recovering a LitClock](recovery.md)
 6. **Power on** via Micro USB (or USB-C if using the [3D-printed case](#3d-printed-case) adapter) — the display should show the boot splash within ~30 seconds
 
 ## E-ink Display Notes

--- a/docs/hardware-assembly.md
+++ b/docs/hardware-assembly.md
@@ -18,8 +18,9 @@
 2. **Connect the HAT** to the Pi's 40-pin GPIO header — align pin 1 and press firmly
 3. **Connect the e-Paper display** to the HAT via the flat ribbon cable — lift the connector latch, slide the cable in (contacts facing down), and close the latch
 4. **Insert the SD card** into the Pi
-5. **SPI is already enabled** by the image — if the display stays blank, check that `/dev/spidev0.0` exists and see [Recovering a LitClock](recovery.md)
-6. **Power on** via Micro USB (or USB-C if using the [3D-printed case](#3d-printed-case) adapter) — the display should show the boot splash within ~30 seconds
+5. **Power on** via Micro USB (or USB-C if using the [3D-printed case](#3d-printed-case) adapter) — the display should show the boot splash within ~30 seconds
+
+SPI is already enabled by the image, so there is nothing to configure. If the display stays blank after a couple of minutes, reseat the ribbon cable and the HAT first — that is the usual cause. If it is still blank you need a shell to go further: [Recovering a LitClock](recovery.md) covers getting console access, and from there `ls /dev/spidev0.0` confirms whether SPI came up.
 
 ## E-ink Display Notes
 

--- a/docs/quote-releases.md
+++ b/docs/quote-releases.md
@@ -81,7 +81,8 @@ If a v2 release introduces a problem:
 
 1. Edit `.images-version` back to `v1` on a branch.
 2. Open a PR, merge.
-3. Trigger `build-image.yml` to cut a fresh OS image pinned to v1.
+3. **Cut a `v*` tag containing the revert.** Deployed Pis resolve the highest semver tag, so a revert that only lands on `master` reaches none of them — they keep running v2 until a tag carries the revert. This step is the rollback; the merge alone is not.
+4. Trigger `build-image.yml` to cut a fresh OS image pinned to v1, so newly flashed cards are correct too.
 
 The v2 release itself can stay on GitHub — nothing consumes it unless a `.images-version` commit points at it.
 

--- a/docs/quote-releases.md
+++ b/docs/quote-releases.md
@@ -51,9 +51,13 @@ The #192 audit tooling can find more changes; folding multiple small corrections
 
 Release creation (`gh release create`) is a side effect on GitHub. Bumping `.images-version` is a source-of-truth change in the repo. Separating them keeps the Git history reviewable in isolation ("this PR shipped image corpus v2") and lets PR review catch a wrong version number before the release is visible to fresh installs.
 
-### Why you must also cut an OS image
+### Why the tag matters, and why you should still cut an OS image
 
-`update.sh` does not run automatically on user devices (by design — see issue #209 for the broader update-policy brainstorm). Existing deployed Pis will stay on whatever image set was baked into their SD flash until a power user manually runs `update.sh`. For a truly zero-maintenance user base, the only path a quote change reaches their device is a fresh flash. So: a quote bump without a paired OS image tag ships to nobody.
+Deployed Pis do pick up quote changes on their own: `litclock-update.timer` runs `update.sh` weekly, and its Phase 2c calls `download_images.sh`, which syncs the image set to whatever `.images-version` pins.
+
+The catch is *which* commit they read that from. `update.sh` does not track `master` — it resolves the highest semver tag and `git reset --hard`s onto that SHA. So a `.images-version` bump sitting on `master` reaches nobody until a `v*` tag contains it. **Merging the bump is not shipping it; tagging is.**
+
+Cutting a fresh OS image is a separate benefit: it bakes the new quote set into the `.img.xz` so a newly flashed card is correct before it ever reaches the network, rather than downloading the corpus on first update.
 
 ## Auth while the repo is private
 

--- a/docs/quote-releases.md
+++ b/docs/quote-releases.md
@@ -2,7 +2,6 @@
 
 Quote images (`images/quote_HHMM_N.png` and `images/metadata/*`) are **not** stored in git. They live as a GitHub Release asset under a tag of the form `litclock-images-vN` and are fetched on demand by:
 
-- `scripts/install.sh` — during a fresh DIY install
 - `scripts/update.sh` — during an in-place update on an existing device (Phase 2c)
 - `.github/workflows/build-image.yml` — when pi-gen bakes an OS image
 

--- a/docs/recovery.md
+++ b/docs/recovery.md
@@ -14,7 +14,7 @@ you probably do not need any of the shell steps below.
 ## Getting a shell (console)
 
 The clock has no keyboard or screen of its own, so "console" means plugging the
-Pi into a monitor (micro-HDMI) and a USB keyboard.
+Pi into a monitor (mini-HDMI on the Zero 2 W) and a USB keyboard.
 
 1. Power off, connect a monitor + keyboard, power on.
 2. Log in at the prompt: user `pi`, password `raspberry`.

--- a/docs/script-reference.md
+++ b/docs/script-reference.md
@@ -11,7 +11,7 @@ Scripts are organized into `scripts/` (shell) and `src/` (Python):
 | `scripts/update.sh` | `./scripts/update.sh` | Pull latest code and apply updates in-place |
 | `scripts/reset-setup.sh` | `sudo ./scripts/reset-setup.sh [--yes] [--reboot] [--wipe-wifi] [--gift-mode]` | Reset configuration (see [Resetting the Clock](../README.md#resetting)); `--gift-mode` preps the device for shipping with a welcome splash |
 | `scripts/prepare-for-cloning.sh` | `sudo ./scripts/prepare-for-cloning.sh` | Wipe config and credentials for SD card cloning (see [Creating SD Cards](sd-card-cloning.md)) |
-| `scripts/install.sh` | `curl -sSL <url> \| bash` | One-line installer (see [DIY Installation](../README.md#2-flash-the-sd-card)) |
+| `scripts/install.sh` | _(retired — do not run)_ | Superseded by the flashed image. Kept for reference only; unmaintained and untested |
 
 ## eink_display.py subcommands
 

--- a/docs/script-reference.md
+++ b/docs/script-reference.md
@@ -11,7 +11,7 @@ Scripts are organized into `scripts/` (shell) and `src/` (Python):
 | `scripts/update.sh` | `./scripts/update.sh` | Pull latest code and apply updates in-place |
 | `scripts/reset-setup.sh` | `sudo ./scripts/reset-setup.sh [--yes] [--reboot] [--wipe-wifi] [--gift-mode]` | Reset configuration (see [Resetting the Clock](../README.md#resetting)); `--gift-mode` preps the device for shipping with a welcome splash |
 | `scripts/prepare-for-cloning.sh` | `sudo ./scripts/prepare-for-cloning.sh` | Wipe config and credentials for SD card cloning (see [Creating SD Cards](sd-card-cloning.md)) |
-| `scripts/install.sh` | _(retired — do not run)_ | Superseded by the flashed image. Kept for reference only; unmaintained and untested |
+| `scripts/install.sh` | _(retired — do not run)_ | Superseded by the flashed image. Kept in the tree and held in sync with the image build by CI, but unsupported as a way to set up a clock and never tested end to end |
 
 ## eink_display.py subcommands
 

--- a/docs/scripts-qa-checklist.md
+++ b/docs/scripts-qa-checklist.md
@@ -16,8 +16,9 @@ This checklist complements the automated tests in `tests/test_*_sh.py` (which co
 ## install.sh — RETIRED, do not QA
 
 The DIY installer is no longer a supported path; the flashed image is the only
-one. The script is kept for reference but is unmaintained and untested, so there
-is nothing here to verify. Flashed-image provisioning is covered by
+one. The script is kept in the tree and held in sync with the image build by CI,
+but it is unsupported as a way to set up a clock and is never exercised on real
+hardware, so there is nothing here to QA. Flashed-image provisioning is covered by
 `first-boot.sh` below and by the in-chroot smoke test in
 `pi-gen/stage3/05-smoke-test/`.
 

--- a/docs/scripts-qa-checklist.md
+++ b/docs/scripts-qa-checklist.md
@@ -13,16 +13,13 @@ This checklist complements the automated tests in `tests/test_*_sh.py` (which co
 
 ---
 
-## install.sh
+## install.sh — RETIRED, do not QA
 
-**Scenario:** Fresh user installs LitClock from scratch on a stock Raspberry Pi OS image.
-
-| # | Test | Expected | Result |
-|---|------|----------|--------|
-| 1 | Run `bash scripts/install.sh` on a stock Pi OS image (Bookworm, user `pi`) | Script completes without errors. All systemd units enabled. `/home/pi/litclock/venv/` exists. | [ ] |
-| 2 | After install: `systemctl is-enabled litclock.timer litclock-firstboot.service litclock-splash.service` | Each returns `enabled` | [ ] |
-| 3 | After install: `ls /home/pi/litclock/env.sh` | File exists and is owned by `pi:pi` | [ ] |
-| 4 | After install: reboot | Boot splash shows on e-ink within 30s | [ ] |
+The DIY installer is no longer a supported path; the flashed image is the only
+one. The script is kept for reference but is unmaintained and untested, so there
+is nothing here to verify. Flashed-image provisioning is covered by
+`first-boot.sh` below and by the in-chroot smoke test in
+`pi-gen/stage3/05-smoke-test/`.
 
 ---
 

--- a/docs/sd-card-cloning.md
+++ b/docs/sd-card-cloning.md
@@ -6,7 +6,7 @@ If you want to make pre-configured SD cards from a working clock:
 
 ## 1. Set Up a Working Clock First
 
-Complete the full installation on one Pi using [Option 2 (DIY Installation)](../README.md#2-flash-the-sd-card). Verify everything works.
+Flash the released LitClock image onto one Pi and finish setup — see [Flash the SD card](../README.md#2-flash-the-sd-card). Verify everything works.
 
 ## 2. Prepare for Cloning
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,9 +1,19 @@
 #!/bin/bash
 #
+# ===========================================================================
+# RETIRED - DO NOT RUN THIS SCRIPT.
+#
+# The one-line `curl ... | bash` install this script used to advertise has
+# been withdrawn. Flash the released LitClock image instead; see the README.
+#
+# This file is kept because CI holds it in sync with the pi-gen image build
+# (package list, systemd units, BCM2835 version) so the two cannot drift. It
+# is not a supported way to set up a clock, and it is not tested end to end
+# on real hardware.
+# ===========================================================================
+#
 # LitClock E-Ink Display Installer
 # For Raspberry Pi Zero WH with Waveshare 7.5" e-Paper HAT (V2)
-#
-# Usage: curl -sSL https://raw.githubusercontent.com/kapoorankush/litclock/master/scripts/install.sh | bash
 #
 # This script will:
 # 1. Install system dependencies


### PR DESCRIPTION
The install command this README documents has been broken for a long time, and fails **silently**.

## The bug

```bash
curl -sSL https://raw.githubusercontent.com/kapoorankush/litclock/master/scripts/install.sh | bash
```

`install.sh` has `set -e` (line 20) and three `read -p` prompts (194, 252, 526). When the script is piped, bash's stdin **is the script stream** and is already at EOF by the time the prompts run — so the first `read` returns non-zero, `set -e` aborts, and the script **exits 0**.

Reproduced:

```
$ printf 'set -e\necho "BANNER"\nread -p "Continue? " r\necho "REACHED"\n' | bash
BANNER
$ echo $?
0
```

Banner, silence, success exit code. Anyone following the documented instructions gets a device that does nothing and no error to search for. Running the script from a file works fine, which is why this went unnoticed — QA only ever flashes images.

Two further defects sit behind the same command: a DIY install can never write `/etc/litclock/.setup-complete` (`first-boot.sh` runs `sudo mkdir` and `sudo tee`, neither authorised by the shipped sudoers allowlist), and SPI is written to the pre-Bookworm `/boot/config.txt` while logging success. `install.sh` also never writes the `dtoverlay=spi0-1cs` line the e-Paper HAT needs, which the image build does.

## What replaces it

Rather than deleting the section, it now answers what that reader actually wanted — running their own code on the clock. The flashed image carries a git checkout at `/home/pi/litclock`, so it doubles as a development environment.

**Every instruction was verified against this repo, not assumed:**

| claim | evidence |
|---|---|
| `.git` survives into the image | `cp -a` in `build-image.yml` and again in `pi-gen/stage3/01-setup-app/00-run.sh`; nothing in `04-finalize` strips it; `git` is the first package installed |
| the clone is shallow, so `--depth 1` is right | `actions/checkout` default `fetch-depth: 1` |
| **SSH ships disabled** | `pi-gen/config` → `ENABLE_SSH=0`. The step links `docs/recovery.md` rather than sending someone into a refused connection |
| the control app is a **separate unit** | `litclock-control.service` is `Type=simple`; restarting only `litclock.service` makes app changes look like they never applied |
| the auto-updater **fires by itself** | `litclock-update.timer` ships enabled, `OnCalendar=Sun 03:00`, `RandomizedDelaySec=7d`, then `git reset --hard`s onto the latest release tag |

That last one matters most: a contributor's branch would be silently discarded at 3am within a week. The off-switch is documented rather than only warning against running the updater by hand. `git checkout -b` replaces a detached HEAD, which no-ops on push.

## Second commit — the rest of the docs

The README fix left six documents still pointing at the installer, two of which **instructed** readers to run it and now contradicted the README:

- **`docs/script-reference.md`** documented `curl -sSL <url> | bash` as the script's usage → marked retired, do not run
- **`docs/hardware-assembly.md`** told readers to enable SPI by hand because *"the installer does this automatically if you use `install.sh`"* — the one step it gets wrong. Its step 1 also flashed stock Raspberry Pi OS, describing the DIY path throughout; now flashes the LitClock image, with SPI noted as already enabled. Verified the image sets `dtparam=spi=on` and the driver opens bus 0 device 0 (`/dev/spidev0.0`).
- **`docs/scripts-qa-checklist.md`** had a four-row QA table for it. Retired — and note it used `bash scripts/install.sh`, the *non-piped* form, which is exactly why QA never caught the pipe failure.
- **`docs/quote-releases.md`**, **`docs/building-image.md`**, **`CONTRIBUTING.md`** described it as a live install path.
- README's two orphaned *"on a DIY install"* mentions go too, since the README no longer describes such a thing.

Anchors were checked rather than assumed: hardware-assembly links `README.md#2-flash-the-sd-card`, the heading that exists — there is no `#installation`. All internal `.md` links in the touched files resolve.

`CONTRIBUTING.md` is CRLF; editing it through Python text mode silently rewrote all 412 line endings and turned two lines into an 824-line diff. Redone in binary.

## Scope

Docs only. `scripts/install.sh` stays in the tree, explicitly marked unmaintained so the non-piped `bash scripts/install.sh` form isn't sanctioned by omission. Removing the file is a separate change.
