### PR TITLE
fix(pi-gen): derive unit install + enable guards from systemd/ (#46)

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -33,10 +33,56 @@ jobs:
       attestations: write   # post attestation to GitHub's attestation store
 
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.inputs.litclock_ref || github.ref }}
           submodules: true
+          # litclock-dev#551 — defense in depth, NOT a live leak. Read the detail before
+          # removing this, and before assuming it is urgent.
+          #
+          # The "Copy checkout into pi-gen" step below runs `cp -a .` mid-job,
+          # so the whole tree including .git is staged into the rootfs at
+          # /home/pi/litclock and ships on every flashed card. .git is kept
+          # deliberately (README Option 2 documents that path as a
+          # build-from-source checkout), so whatever checkout leaves in
+          # .git/config ships with it.
+          #
+          # What checkout actually leaves there depends on its version:
+          #   v4.2.2  — wrote the real token into .git/config as an
+          #             `http.<origin>/.extraheader` AUTHORIZATION line.
+          #   v6.0.0+ — writes the token to a separate file under $RUNNER_TEMP
+          #             and leaves only an include/includeIf reference in
+          #             .git/config (src/git-auth-helper.ts::configureToken).
+          #
+          # This workflow has pinned v6+ since 2026-04-15 and v7 since
+          # 2026-07-01, and no release in either repo predates that, so no
+          # published image has ever carried the token. With v7 the staged
+          # .git/config holds only a dangling path into a runner temp dir.
+          #
+          # Setting this anyway because the job needs no git credential at all
+          # (it only runs `git rev-parse HEAD`; every `gh` call takes its token
+          # from the environment), so the correct posture is to not request one
+          # — which also holds if a future checkout version changes the
+          # mechanism back, or if someone downgrades the pin.
+          persist-credentials: false
+
+      # Image-correctness tests, BEFORE the 40-minute build.
+      #
+      # tests/test_pi_gen.py is the gate that decides whether the units, the
+      # tmpfiles drop-in and the [Install] directives are sane. Without this step
+      # it never ran during a build at all: this workflow is a single `build` job
+      # with no `needs:`, so moving the [Install]-validity check out of
+      # 05-smoke-test and into pytest quietly moved it off the release path
+      # entirely. A `WnatedBy=` typo would have shipped.
+      #
+      # Runs early on purpose — a broken tree fails in ~1 minute instead of at
+      # minute 38 of a 40-minute build. Deliberately NOT the whole suite: this
+      # needs only pytest + PyYAML, no Pillow/hardware deps, so it cannot become
+      # a flaky gate on an unrelated test.
+      - name: Image-correctness tests
+        run: |
+          python3 -m pip install --quiet --upgrade pytest pyyaml
+          python3 -m pytest tests/test_pi_gen.py tests/test_build_image_workflow.py -q
 
       # Free disk space — pi-gen needs ~10 GB
       - name: Free disk space
@@ -53,25 +99,43 @@ jobs:
           REF_NAME: ${{ github.ref_name }}
           DISPATCH_REF: ${{ github.event.inputs.litclock_ref || 'master' }}
         run: |
-          # The commit the image is actually built from = the checked-out
-          # HEAD (which honors litclock_ref), NOT github.sha (the dispatch
-          # ref's HEAD). These diverge when litclock_ref != the dispatch ref,
-          # and the promote job later tags the release at this commit — so it
-          # must be the built one. On a tag push they're identical.
-          BUILT_SHA=$(git rev-parse HEAD)
+          # Use the SHA actually CHECKED OUT, not GITHUB_SHA. On a
+          # workflow_dispatch, GITHUB_SHA is the SHA of the ref the workflow
+          # FILE came from (master), not the litclock_ref that was checked out
+          # at the step above — so a dev build of a feature branch was tagged
+          # and stamped with master's SHA. That mislabelled both the release
+          # asset name and the git_sha= line in /etc/litclock-version, making a
+          # QA artifact impossible to trace back to the code inside it.
+          #
+          # Correct for BOTH paths: on a tag push HEAD *is* the tagged commit,
+          # so this is a no-op for real releases and only fixes dispatch builds.
+          # The checkout step runs before this one, so HEAD is already resolved.
+          # Full SHA first, then slice it. `git rev-parse --short=7` returns a
+          # MINIMUM of 7 characters and lengthens on collision or when
+          # core.abbrev is set, and this string becomes the dev tag, the .img
+          # asset name and git_sha= in /etc/litclock-version. A positional slice
+          # is deterministic. Full form is also what `gh release create --target`
+          # needs: target_commitish takes a branch name or a full commit SHA, and
+          # a 7-char abbreviation is not guaranteed to resolve.
+          RESOLVED_FULL_SHA="$(git rev-parse HEAD)"
+          RESOLVED_SHA="${RESOLVED_FULL_SHA:0:7}"
           if [[ "${REF_TYPE}" == "tag" ]]; then
             VERSION="${REF_NAME}"
             VERSION="${VERSION#v}"  # strip leading v
             REF="${REF_NAME}"
           else
-            VERSION="dev-$(date +%Y%m%d)-${BUILT_SHA:0:7}"
+            # `dev-` prefix is load-bearing: the stale-dev-release cleanup step
+            # below selects on startswith("dev-"), and the OTA resolver
+            # (scripts/lib/github_api.sh) filters tags to vMAJOR.MINOR.PATCH so
+            # dev tags stay invisible to fielded clocks.
+            VERSION="dev-$(date +%Y%m%d)-${RESOLVED_SHA}"
             REF="${DISPATCH_REF}"
           fi
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
           echo "ref=${REF}" >> "$GITHUB_OUTPUT"
-          echo "sha=${BUILT_SHA:0:7}" >> "$GITHUB_OUTPUT"
-          echo "commit=${BUILT_SHA}" >> "$GITHUB_OUTPUT"
-          echo "Version: ${VERSION}, Ref: ${REF}, Commit: ${BUILT_SHA}"
+          echo "sha=${RESOLVED_SHA}" >> "$GITHUB_OUTPUT"
+          echo "full_sha=${RESOLVED_FULL_SHA}" >> "$GITHUB_OUTPUT"
+          echo "Version: ${VERSION}, Ref: ${REF}, SHA: ${RESOLVED_SHA}"
 
       # pi-gen builds arm64 images via QEMU emulation on x86 runners
       - name: Set up QEMU
@@ -95,14 +159,25 @@ jobs:
           fi
 
       - name: Configure pi-gen
+        # Through `env:`, not `${{ }}` inline. LITCLOCK_REF derives from
+        # github.event.inputs.litclock_ref, which is attacker-controlled text on
+        # the dispatch path; `${{ }}` splices it into the script BEFORE bash sees
+        # it, so `master$(...)` executed arbitrary code on a runner holding
+        # contents:write + id-token:write + attestations:write — i.e. one that
+        # can build, sign and publish a release image. Quoted shell variables
+        # cannot be re-parsed that way.
+        env:
+          REF: ${{ steps.version.outputs.ref }}
+          VERSION: ${{ steps.version.outputs.version }}
+          SHA: ${{ steps.version.outputs.sha }}
         run: |
           # Copy base config
           cp pi-gen/config /tmp/pi-gen/config
 
           # Append build-time variables
-          echo "LITCLOCK_REF=${{ steps.version.outputs.ref }}" >> /tmp/pi-gen/config
-          echo "LITCLOCK_VERSION=${{ steps.version.outputs.version }}" >> /tmp/pi-gen/config
-          echo "LITCLOCK_SHA=${{ steps.version.outputs.sha }}" >> /tmp/pi-gen/config
+          echo "LITCLOCK_REF=${REF}" >> /tmp/pi-gen/config
+          echo "LITCLOCK_VERSION=${VERSION}" >> /tmp/pi-gen/config
+          echo "LITCLOCK_SHA=${SHA}" >> /tmp/pi-gen/config
 
           # Replace pi-gen's default stage3 with our custom stage
           rm -rf /tmp/pi-gen/stage3
@@ -198,6 +273,11 @@ jobs:
 
       - name: Compress image
         id: compress
+        # VERSION via env: for the same reason as the other steps — on a tag
+        # push it is github.ref_name with the leading v stripped, i.e.
+        # ref-derived text reaching a shell string.
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
         run: |
           DEPLOY=/tmp/pi-gen/deploy
 
@@ -215,7 +295,7 @@ jobs:
             exit 1
           fi
 
-          IMG_NAME="litclock-${{ steps.version.outputs.version }}.img"
+          IMG_NAME="litclock-${VERSION}.img"
 
           # Rename to versioned name
           mv "${IMG}" "/tmp/${IMG_NAME}"
@@ -250,10 +330,17 @@ jobs:
       # unlike artifacts which accrue GB-hours against the 500 MB free tier)
       - name: Upload dev build
         if: github.ref_type != 'tag'
+        # REF through `env:` for the same reason as Configure pi-gen: it carries
+        # the dispatch input verbatim, and `${{ }}` inside a double-quoted shell
+        # string is re-parsed by bash, so `master$(...)` would execute here.
         env:
           GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.version.outputs.version }}
+          REF: ${{ steps.version.outputs.ref }}
+          TARGET_SHA: ${{ steps.version.outputs.full_sha }}
+          IMG: ${{ steps.compress.outputs.img }}
+          SHA: ${{ steps.compress.outputs.sha }}
         run: |
-          TAG="${{ steps.version.outputs.version }}"
           # Delete existing release with this tag (idempotent re-runs)
           gh release delete "${TAG}" --yes --cleanup-tag 2>/dev/null || true
           # Clean up dev releases older than 7 days
@@ -262,11 +349,11 @@ jobs:
           | xargs -I{} gh release delete {} --yes --cleanup-tag 2>/dev/null || true
           gh release create "${TAG}" \
             --prerelease \
-            --title "Dev build ${{ steps.version.outputs.version }}" \
-            --notes "Dev build from \`${{ steps.version.outputs.ref }}\` ($(date -u +%Y-%m-%dT%H:%M:%SZ)). Auto-generated, not for production use." \
-            --target "${{ steps.version.outputs.commit }}" \
-            "${{ steps.compress.outputs.img }}" \
-            "${{ steps.compress.outputs.sha }}"
+            --title "Dev build ${TAG}" \
+            --notes "Dev build from \`${REF}\` ($(date -u +%Y-%m-%dT%H:%M:%SZ)). Auto-generated, not for production use." \
+            --target "${TARGET_SHA}" \
+            "${IMG}" \
+            "${SHA}"
 
       # On tag push: create GitHub Release
       #
@@ -276,6 +363,22 @@ jobs:
       # git rev-list, but downstream tooling (and any future resolver that
       # trusts target_commitish) needs honest metadata. Always stamp the
       # actual commit SHA so the Release points where everyone thinks it does.
+      #
+      # Both release steps pass steps.version.outputs.full_sha, never
+      # github.sha. Where it actually BITES is the dispatch path: there gh
+      # creates the dev- tag itself, so target_commitish decides where the tag
+      # lands, and github.sha is the SHA of the ref the workflow FILE came from
+      # (master) — every dev Release pointed at master while the image inside
+      # held a feature branch.
+      #
+      # On THIS path the tag already exists (the push created it), and GitHub
+      # documents target_commitish as unused when the tag exists — so --target
+      # here is honest metadata rather than load-bearing. Both steps follow the
+      # same rule anyway, because one rule beats two plus a footnote about which
+      # path each is safe on.
+      #
+      # Note the --clobber branch below cannot set target_commitish at all; it
+      # does not need to, for the reason above.
       - name: Create release
         if: github.ref_type == 'tag'
         env:
@@ -283,6 +386,8 @@ jobs:
           REF_NAME: ${{ github.ref_name }}
           IMG: ${{ steps.compress.outputs.img }}
           SHA: ${{ steps.compress.outputs.sha }}
+          VERSION: ${{ steps.version.outputs.version }}
+          TARGET_SHA: ${{ steps.version.outputs.full_sha }}
         # Idempotent: if a release with this tag already exists (someone
         # pre-cut it manually with curated notes, or a prior workflow run
         # got this far and partial-failed), upload the assets to it with
@@ -295,12 +400,13 @@ jobs:
             gh release upload "${REF_NAME}" "${IMG}" "${SHA}" --clobber
           else
             gh release create "${REF_NAME}" \
-              --title "LitClock ${{ steps.version.outputs.version }}" \
-              --target "${{ steps.version.outputs.commit }}" \
+              --title "LitClock ${VERSION}" \
+              --target "${TARGET_SHA}" \
               --generate-notes \
               "${IMG}" \
               "${SHA}"
           fi
+
 
   # ─────────────────────────────────────────────────────────────────────
   # PROMOTE mode (build-once, ship-what-you-tested)
@@ -349,7 +455,7 @@ jobs:
       group: promote-${{ github.event.inputs.release_version }}
       cancel-in-progress: false
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 1
 

--- a/pi-gen/stage3/03-install-services/00-run.sh
+++ b/pi-gen/stage3/03-install-services/00-run.sh
@@ -7,44 +7,93 @@ set -e
 
 INSTALL_DIR="/home/pi/litclock"
 
-# Copy all systemd units
-cp "${INSTALL_DIR}/systemd/litclock-splash.service" /etc/systemd/system/
-cp "${INSTALL_DIR}/systemd/litclock-firstboot.service" /etc/systemd/system/
-cp "${INSTALL_DIR}/systemd/litclock.service" /etc/systemd/system/
-cp "${INSTALL_DIR}/systemd/litclock.timer" /etc/systemd/system/
-cp "${INSTALL_DIR}/systemd/litclock-shutdown.service" /etc/systemd/system/
-cp "${INSTALL_DIR}/systemd/wifi-watchdog.service" /etc/systemd/system/
-cp "${INSTALL_DIR}/systemd/wifi-watchdog.timer" /etc/systemd/system/
-# #209 — weekly auto-update + #241 — LKG poll timer
-cp "${INSTALL_DIR}/systemd/litclock-update.service" /etc/systemd/system/
-cp "${INSTALL_DIR}/systemd/litclock-update.timer" /etc/systemd/system/
-cp "${INSTALL_DIR}/systemd/litclock-lkg.service" /etc/systemd/system/
-cp "${INSTALL_DIR}/systemd/litclock-lkg.timer" /etc/systemd/system/
-# #209 follow-up — LKG auto-revert consumer (bootcheck). Timer-driven
-# oneshot; service has no [Install] (started by the .timer), so only the
-# timer is enabled below. Same missing-cp-breaks-fresh-image trap.
-cp "${INSTALL_DIR}/systemd/litclock-bootcheck.service" /etc/systemd/system/
-cp "${INSTALL_DIR}/systemd/litclock-bootcheck.timer" /etc/systemd/system/
-# EPIC #383 PR2 (#388) — handoff last-resort completer. Timer-driven oneshot;
-# the .service has no [Install] (started by the .timer), so only the timer is
-# enabled below. Same missing-cp-breaks-fresh-image trap as wifi-reset.
-cp "${INSTALL_DIR}/systemd/litclock-handoff-fallback.service" /etc/systemd/system/
-cp "${INSTALL_DIR}/systemd/litclock-handoff-fallback.timer" /etc/systemd/system/
-# #245 M1 — Control PWA always-on management surface
-cp "${INSTALL_DIR}/systemd/litclock-control.service" /etc/systemd/system/
-# #245 M5 D11 — Reset-WiFi flow (fired on demand by /api/wifi/reset).
-# Type=oneshot + no [Install] → no enable needed; sudoers only allows
-# `systemctl start --no-block litclock-wifi-reset.service`. Missing this
-# cp silently broke Reset WiFi on every fresh-image install from v0.211.0
-# until v0.211.1; install.sh + update.sh paths were unaffected (caught in
-# M8 hardware QA on test Pi 2026-05-13).
-cp "${INSTALL_DIR}/systemd/litclock-wifi-reset.service" /etc/systemd/system/
-# #245 M8-prep / #280 — Prepare-for-Gifting (fired by /api/system/prepare-for-gift).
-# Same shape as wifi-reset above; same install-path gap; same fix.
-cp "${INSTALL_DIR}/systemd/litclock-prepare-for-gift.service" /etc/systemd/system/
-# #510 — Factory reset (fired by /api/system/reset). Same shape as the two units
-# above (Type=oneshot, no [Install], sudoers start-only); same install-path gap.
-cp "${INSTALL_DIR}/systemd/litclock-reset.service" /etc/systemd/system/
+# Destinations, named so tests/test_pi_gen.py can run the shipped loops below
+# against a fake tree. Unconditional assignments, never `${VAR:-default}`:
+# on_chroot uses capsh, which does not scrub the environment, so an overridable
+# seam would let a stray exported variable redirect where a ROOT-run build
+# script installs. The tests inject their own assignments ahead of the
+# sentinel-extracted blocks, so they need no seam here — see the same decision
+# in 05-smoke-test.
+ETC_SYSTEMD_DIR=/etc/systemd/system
+ETC_TMPFILES_DIR=/etc/tmpfiles.d
+
+# ── Copy systemd units ───────────────────────────────────────────────
+#
+# Globbed, NOT enumerated. A hand-maintained cp list drifted three times:
+#   * v0.211.0 — litclock-wifi-reset.service + litclock-prepare-for-gift.service
+#     were never copied. The PWA's Reset WiFi and Prepare-for-Gifting buttons
+#     accepted the confirm tap then failed with `Unit not found` on every
+#     flashed image until v0.211.1. install.sh + update.sh were unaffected.
+#   * #14 — install.sh enabled units it never copied; under set -e the
+#     systemctl enable aborted the whole DIY install.
+#   * litclock-dev#547 — litclock-reresolve-location.service reached NO flashed image
+#     at all, so #337's on-boot IP-geo re-resolve silently never ran on a
+#     fresh flash. update.sh's glob installed it, so it only appeared after
+#     the first OTA.
+# A glob cannot forget a new unit. scripts/update.sh has used one for years —
+# see its `for unit in "$INSTALL_DIR"/systemd/*.service "$INSTALL_DIR"/systemd/*.timer`
+# loop — and its UNIT install has never had a member of this bug class. Note the
+# suffix filter: a bare `/systemd/*` is exactly the glob that would also have
+# covered tmpfiles.d/, and the drop-in below was in fact a hardcoded name in
+# both this file and update.sh until litclock-dev#547. The glob habit held for units and
+# did not extend to the one thing that was not a unit.
+#
+# The tradeoff a glob introduces: an unmatched glob is NOT an error. A wrong
+# INSTALL_DIR, a renamed systemd/, or a half-failed 01-setup-app would copy
+# zero units, exit 0, and ship an inert image. The hardcoded list failed
+# LOUDLY there (cp errors under set -e). The assertions below restore that
+# loudness. They are derived (found vs copied) rather than an exact inventory
+# so that adding a unit needs no edit here — an exact count would just be the
+# next drift bug.
+#
+# `install -m 0644 -o root -g root` rather than `cp`: cp applies the SOURCE
+# file's mode to a new destination, so a unit committed with the exec bit set
+# would land executable in /etc/systemd/system/. This also matches the helper
+# installs further down instead of using two different idioms for the same job.
+# BEGIN unit-copy-loop (tests/test_pi_gen.py extracts between these sentinels
+# and runs them under bash against a fake tree with a recording `install` stub)
+shopt -s nullglob
+units=( "${INSTALL_DIR}"/systemd/*.service "${INSTALL_DIR}"/systemd/*.timer )
+shopt -u nullglob
+
+found=${#units[@]}
+copied=0
+for unit in "${units[@]}"; do
+    # 01-setup-app stages the repo with `cp -a`, which preserves symlinks. A
+    # symlinked unit would have its target's content silently copied out, so
+    # require a plain regular file.
+    if [ ! -f "$unit" ] || [ -L "$unit" ]; then
+        echo "FAIL: ${unit} is not a regular file." >&2
+        exit 1
+    fi
+    install -m 0644 -o root -g root "$unit" "${ETC_SYSTEMD_DIR}/"
+    copied=$(( copied + 1 ))
+done
+# END unit-copy-loop
+
+# Sanity floor. Deliberately well BELOW the real unit count and deliberately
+# NOT an inventory: adding units must never require touching this number. It
+# exists only to catch a source tree that is empty or nearly so — the
+# half-failed-01-setup-app case, which found==copied cannot detect because
+# both would simply be small.
+# BEGIN copy-guard (tests/test_pi_gen.py extracts the assertions between these
+# sentinels and runs them under bash with tampered counts)
+MIN_EXPECTED_UNITS=10
+if [ "$found" -lt "$MIN_EXPECTED_UNITS" ]; then
+    echo "FAIL: only ${found} unit files under ${INSTALL_DIR}/systemd/ (floor is ${MIN_EXPECTED_UNITS})." >&2
+    echo "      The repo was probably not staged correctly by 01-setup-app." >&2
+    exit 1
+fi
+# Belt-and-braces only: on_chroot runs bash with errexit, so a failing install
+# aborts before this comparison is ever reached. The FLOOR above is the guard
+# that actually restores the loudness the hardcoded cp list gave us. Kept
+# because it is free and would catch a future refactor that drops errexit.
+if [ "$copied" -ne "$found" ]; then
+    echo "FAIL: found ${found} unit files but copied ${copied}." >&2
+    exit 1
+fi
+# END copy-guard
+echo "  OK: copied ${copied} systemd units from ${INSTALL_DIR}/systemd/"
 
 # #309 — NetworkManager dispatcher: re-render the e-ink corner QR when
 # wlan0's IP changes so the displayed address tracks reality after DHCP
@@ -76,27 +125,110 @@ install -m 0644 -o root -g root \
     "${INSTALL_DIR}/scripts/lib/state.sh" \
     /usr/local/lib/litclock/lib/state.sh
 
-# #241 — tmpfs heartbeat directory created on every boot
-cp "${INSTALL_DIR}/systemd/tmpfiles.d/litclock.conf" /etc/tmpfiles.d/
+# ── Copy systemd-tmpfiles drop-ins ───────────────────────────────────
+#
+# #241 — /run/litclock, the tmpfs heartbeat directory, plus #245 M5's
+# /var/lib/litclock persistent state directory. Both are created on every boot
+# by systemd-tmpfiles from the drop-in copied here.
+#
+# Globbed and guarded for exactly the reason the unit copy above is. This WAS a
+# bare hardcoded `cp` — invisible to every guard in this file, and invisible to
+# 05-smoke-test too, whose derived checks globbed *.service/*.timer at the first
+# level of systemd/ and never descended into tmpfiles.d/. So it was litclock-dev#547's own
+# shape sitting inside litclock-dev#547's directory. 05 now derives *.conf from
+# systemd/tmpfiles.d/ and also asserts /etc/tmpfiles.d/litclock.conf by absolute
+# path, so both gates cover it.
+#
+# What a missing drop-in actually breaks, precisely: the writers that run as
+# root or via sudo survive it, because scripts/lib/state.sh:62,
+# scripts/lib/update_status.sh:77, scripts/wifi-watchdog.sh:130,
+# scripts/litclock-lkg-record.sh:63 and scripts/litclock-bootcheck.sh:128 all
+# `mkdir -p` their parent with a sudo fallback, and the NM dispatcher already
+# creates /run/litclock outright. So lkg-sha, update-failed, the post-update
+# grace marker and update.status keep working. What genuinely breaks is the
+# PI-OWNED /run writers, which cannot mkdir in a root-owned /run:
+# src/literary_clock.py's HEARTBEAT_FILE and the weather cache in
+# src/weather_providers/base_provider.py. The drop-in's other job is ownership
+# normalisation — pre-M5 installs left /var/lib/litclock root-owned.
+#
+# (An earlier version of this comment claimed the whole list no-ops. It does
+# not, and the sudo-mkdir fallbacks are the reason — do not delete them as
+# redundant on the strength of a doom comment.)
+# BEGIN tmpfiles-copy-loop (tests/test_pi_gen.py extracts between these sentinels)
+shopt -s nullglob
+tmpfiles_confs=( "${INSTALL_DIR}"/systemd/tmpfiles.d/*.conf )
+shopt -u nullglob
 
-# Enable services (systemctl enable works in chroot — it creates symlinks)
+install -d -m 0755 "${ETC_TMPFILES_DIR}"
+tmpfiles_found=${#tmpfiles_confs[@]}
+tmpfiles_copied=0
+for conf in "${tmpfiles_confs[@]}"; do
+    # Same regular-file requirement as the units: 01-setup-app stages with
+    # `cp -a`, so a symlink here would have its target's content copied out.
+    if [ ! -f "$conf" ] || [ -L "$conf" ]; then
+        echo "FAIL: ${conf} is not a regular file." >&2
+        exit 1
+    fi
+    install -m 0644 -o root -g root "$conf" "${ETC_TMPFILES_DIR}/"
+    tmpfiles_copied=$(( tmpfiles_copied + 1 ))
+done
+# END tmpfiles-copy-loop
+
+# BEGIN tmpfiles-guard (tests/test_pi_gen.py extracts the assertions between
+# these sentinels and runs them under bash with tampered counts)
+# Floor of 1, not an inventory: the glob matching nothing is the whole failure
+# this restores loudness for. `cp` failed loudly under errexit; a glob does not.
+MIN_EXPECTED_TMPFILES=1
+if [ "$tmpfiles_found" -lt "$MIN_EXPECTED_TMPFILES" ]; then
+    echo "FAIL: no tmpfiles.d drop-ins under ${INSTALL_DIR}/systemd/tmpfiles.d/ (floor is ${MIN_EXPECTED_TMPFILES})." >&2
+    echo "      /run/litclock and /var/lib/litclock would never be created." >&2
+    exit 1
+fi
+if [ "$tmpfiles_copied" -ne "$tmpfiles_found" ]; then
+    echo "FAIL: found ${tmpfiles_found} tmpfiles.d drop-ins but copied ${tmpfiles_copied}." >&2
+    exit 1
+fi
+# END tmpfiles-guard
+echo "  OK: copied ${tmpfiles_copied} tmpfiles.d drop-in(s) from ${INSTALL_DIR}/systemd/tmpfiles.d/"
+
+# ── Enable units ─────────────────────────────────────────────────────
+#
+# This list stays EXPLICIT, unlike the copy above. Enablement is a policy
+# decision, not an inventory: litclock.timer ships an [Install] section but
+# must NOT be enabled at build time. Deriving enablement from [Install] would
+# start the clock before provisioning finishes.
+#
+# The guard against silent omission lives in tests/test_pi_gen.py: every unit
+# in systemd/ carrying an [Install] section must appear either in this list or
+# in BUILD_ENABLE_EXCLUSIONS below. A new unit that needs enabling therefore
+# fails the test suite rather than shipping quietly disabled.
+#
+# systemctl enable works in chroot — it creates the .wants symlinks directly.
+
+# Units with [Install] deliberately NOT enabled at image-build time.
+# tests/test_pi_gen.py parses this array — keep it one bare name per line.
+BUILD_ENABLE_EXCLUSIONS=(
+    litclock.timer
+)
+# litclock.timer — first-boot.sh enables it after setup completes, and it stays
+# enabled for subsequent boots. Enabling at build time would race splash and
+# firstboot for GPIO access before setup is done.
+
 systemctl enable litclock-splash.service
 systemctl enable litclock-firstboot.service
-# litclock.timer is NOT enabled here — first-boot.sh enables it after setup completes,
-# and it stays enabled for subsequent boots. Enabling it at build time would race with
-# splash/firstboot for GPIO access before setup is done.
 systemctl enable litclock-shutdown.service
 systemctl enable wifi-watchdog.timer
 # #209 — weekly auto-update. Timer safe to enable at build time: first
 # trigger is OnCalendar=Sun 03:00 + up to 7d jitter, which only fires after
-# first-boot finishes and litclock.service has been running for ≥1 hour.
+# first-boot finishes and litclock.service has been running for >=1 hour.
 # ConditionPathExists=/etc/litclock/.setup-complete in the service blocks
 # any pre-firstboot fire (the flag is only written by first-boot.sh on
 # successful WiFi/setup completion).
 # #241 — LKG poll timer; service has no [Install], so enable the timer.
 systemctl enable litclock-update.timer
 systemctl enable litclock-lkg.timer
-# #209 follow-up — LKG auto-revert (bootcheck) poll timer.
+# #209 follow-up — LKG auto-revert (bootcheck) poll timer. The .service has no
+# [Install] (it is started by the .timer), so only the timer is enabled.
 systemctl enable litclock-bootcheck.timer
 # EPIC #383 PR2 (#388) — handoff fallback poll timer (service has no [Install]).
 systemctl enable litclock-handoff-fallback.timer
@@ -104,4 +236,34 @@ systemctl enable litclock-handoff-fallback.timer
 # gates startup; on a fresh image the unit waits until first-boot writes the
 # flag, then comes up automatically.
 systemctl enable litclock-control.service
+# #337 A2/A8 / litclock-dev#547 — on-boot IP-geo re-resolve oneshot. WantedBy=multi-user
+# .target, gated at runtime by ConditionPathExists=/etc/litclock/.handoff-complete
+# so it no-ops until setup + handoff finish.
+#
+# MUST be enabled in the SAME release that first copies it. scripts/update.sh
+# decides whether to auto-enable a unit by whether the unit FILE already exists
+# in /etc/systemd/system/ (its `was_pre_existing` check). An intermediate image that copied
+# this unit without enabling it would leave it PERMANENTLY disabled on every Pi
+# flashed from that image: every later OTA would see the file present, treat it
+# as pre-existing, and respect a user choice that was never made.
+systemctl enable litclock-reresolve-location.service
+
+# Sanity: anything named in BUILD_ENABLE_EXCLUSIONS must actually be un-enabled.
+# Catches an enable line added above without removing the unit from the
+# exclusion list, which would otherwise leave the two silently contradictory.
+#
+# Checks EVERY *.wants directory, not a hardcoded pair. An excluded unit wanted
+# by sockets.target, graphical.target or a custom target would sail past a
+# two-directory check while actually being enabled — a guard that cannot fail
+# is the exact failure mode this file exists to remove.
+# BEGIN enable-exclusion-check (tests/test_pi_gen.py extracts between these sentinels)
+for excluded in "${BUILD_ENABLE_EXCLUSIONS[@]}"; do
+    if compgen -G "${ETC_SYSTEMD_DIR}/*.wants/${excluded}" > /dev/null; then
+        echo "FAIL: ${excluded} is listed in BUILD_ENABLE_EXCLUSIONS but was enabled:" >&2
+        compgen -G "${ETC_SYSTEMD_DIR}/*.wants/${excluded}" >&2
+        exit 1
+    fi
+done
+# END enable-exclusion-check
+echo "  OK: enable-set applied, ${#BUILD_ENABLE_EXCLUSIONS[@]} deliberate exclusion(s) verified un-enabled"
 CHROOT

--- a/pi-gen/stage3/05-smoke-test/00-run.sh
+++ b/pi-gen/stage3/05-smoke-test/00-run.sh
@@ -18,6 +18,9 @@ set -e
 echo "=== In-chroot smoke test ==="
 
 echo "-- Required files --"
+# Non-unit runtime files stay an explicit curated list: their absence is not
+# derivable from anywhere else in the tree. Systemd units are NOT listed here
+# any more — see the derived check below.
 required_files=(
     /home/pi/litclock/venv/bin/python3
     /home/pi/litclock/venv/pyvenv.cfg
@@ -28,14 +31,40 @@ required_files=(
     /home/pi/litclock/scripts/first-boot.sh
     /home/pi/litclock/scripts/boot-splash.sh
     /home/pi/litclock/requirements.txt
+    /usr/local/bin/wifi-watchdog.sh
+    # Load-bearing units, asserted by ABSOLUTE PATH on purpose. The derived
+    # check below reads the same source tree that 03-install-services copies
+    # from, so if that tree is wrong both gates agree and both pass. These
+    # three do not depend on the source tree at all, so the two checks fail on
+    # different causes: the derived one catches drift, this one catches source
+    # corruption.
+    #
+    # Why these three: only 10 of the 20 units are named in a `systemctl enable`
+    # line, which is what makes a missing file abort stage 03. The other 10 have
+    # no such backstop, and litclock.service + litclock.timer are the ones whose
+    # absence is silent AND fatal — first-boot.sh guards the timer with
+    # `if systemctl list-unit-files | grep -q litclock.timer`, a soft if, so a
+    # missing timer is skipped with no error and no journal line. The clock
+    # finishes setup, shows the handoff splash, and never paints a quote, on a
+    # device with no keyboard attached.
+    #
+    # wifi-watchdog.service is the third for a different reason: it carries no
+    # [Install] section, so no `systemctl enable` line names it and the derived
+    # enable check below skips it. wifi-watchdog.timer's Unit= reference to it is
+    # resolved by systemd at RUNTIME, so its absence is invisible to every
+    # build-time check and surfaces only as a timer that fails on the device.
     /etc/systemd/system/litclock.service
     /etc/systemd/system/litclock.timer
-    /etc/systemd/system/litclock-splash.service
-    /etc/systemd/system/litclock-firstboot.service
-    /etc/systemd/system/litclock-shutdown.service
     /etc/systemd/system/wifi-watchdog.service
-    /etc/systemd/system/wifi-watchdog.timer
-    /usr/local/bin/wifi-watchdog.sh
+    # Same independent-backstop role, for the tmpfiles drop-in. It creates
+    # /run/litclock and /var/lib/litclock. When it is absent the root/sudo
+    # writers survive (they mkdir their own parent — see the note in
+    # 03-install-services), but the PI-OWNED /run writers cannot: the render
+    # heartbeat in src/literary_clock.py and the weather cache in
+    # src/weather_providers/base_provider.py both fail, and /var/lib/litclock
+    # loses its ownership normalisation. There is no journal line for a
+    # directory that was never asked for.
+    /etc/tmpfiles.d/litclock.conf
 )
 for f in "${required_files[@]}"; do
     if [ ! -e "$f" ]; then
@@ -43,28 +72,244 @@ for f in "${required_files[@]}"; do
         exit 1
     fi
 done
-echo "  OK: ${#required_files[@]} required files present"
+echo "  OK: ${#required_files[@]} required runtime files present"
 
-echo "-- Systemd enable symlinks --"
-# These are enabled at build time (stage3/03-install-services).
-# litclock.timer is NOT — first-boot.sh enables it after setup.
-enabled_units=(
-    /etc/systemd/system/multi-user.target.wants/litclock-splash.service
-    /etc/systemd/system/multi-user.target.wants/litclock-firstboot.service
-    /etc/systemd/system/multi-user.target.wants/litclock-shutdown.service
-    /etc/systemd/system/timers.target.wants/wifi-watchdog.timer
-)
-for link in "${enabled_units[@]}"; do
-    if [ ! -L "$link" ] && [ ! -e "$link" ]; then
-        echo "FAIL: expected enable symlink $link missing"
+echo "-- Installed systemd units (derived from the source tree) --"
+# DERIVED, not enumerated. The previous hardcoded list named only a third of the
+# units in systemd/, so this smoke test — the last gate before an image is produced —
+# passed green while litclock-reresolve-location.service reached no flashed
+# image at all (litclock-dev#547).
+#
+# Comparing the installed set against the SOURCE tree is the only check that
+# cannot drift as units are added, and it runs in the repo->image direction,
+# which is the direction the bug actually travels. The old
+# test_pi_gen.py::test_all_copied_units_exist_in_repo checked image->repo,
+# which structurally cannot catch a unit that was never installed.
+# Unconditional on purpose. These were briefly `${VAR:-default}` so tests could
+# redirect them, but that bought nothing: the sentinel-extracted blocks below
+# do not include these lines, and tests/test_pi_gen.py injects its own
+# assignments ahead of the extracted block. All the indirection did was let a
+# stray environment variable redirect where a ROOT-run build script reads its
+# source of truth and verifies the installed result — point ETC_SYSTEMD_DIR at
+# the source tree and every `cmp -s` compares a file to itself, so all three
+# checks pass green on an image nobody inspected. That is the exact
+# silently-wrong-image class litclock-dev#547 exists to close.
+SRC_SYSTEMD_DIR=/home/pi/litclock/systemd
+ETC_SYSTEMD_DIR=/etc/systemd/system
+
+# BEGIN unit-install-check (tests/test_pi_gen.py extracts between these sentinels)
+shopt -s nullglob
+src_units=( "$SRC_SYSTEMD_DIR"/*.service "$SRC_SYSTEMD_DIR"/*.timer )
+shopt -u nullglob
+# Same floor as 03-install-services. tests/test_pi_gen.py asserts the two values
+# stay equal, so they cannot drift apart.
+MIN_EXPECTED_UNITS=10
+if [ "${#src_units[@]}" -lt "$MIN_EXPECTED_UNITS" ]; then
+    echo "FAIL: only ${#src_units[@]} unit files in ${SRC_SYSTEMD_DIR} — repo staging is broken"
+    exit 1
+fi
+for src in "${src_units[@]}"; do
+    name=$(basename "$src")
+    if [ ! -e "${ETC_SYSTEMD_DIR}/${name}" ]; then
+        echo "FAIL: ${name} exists in systemd/ but was never installed to ${ETC_SYSTEMD_DIR}/"
+        exit 1
+    fi
+    # Existence is not enough. A stale unit left in /etc/systemd/system/ by a
+    # reused pi-gen work directory (CLEAN=0) satisfies -e while differing from
+    # what this build staged, so the image would ship a unit nobody reviewed.
+    if ! cmp -s "$src" "${ETC_SYSTEMD_DIR}/${name}"; then
+        echo "FAIL: ${ETC_SYSTEMD_DIR}/${name} differs from the staged source ${src}"
         exit 1
     fi
 done
-if [ -e /etc/systemd/system/timers.target.wants/litclock.timer ]; then
-    echo "FAIL: litclock.timer is enabled at build time (must be deferred to first-boot.sh)"
+# END unit-install-check
+echo "  OK: all ${#src_units[@]} source units installed to ${ETC_SYSTEMD_DIR}/ and match the source"
+
+echo "-- systemd-tmpfiles drop-ins (derived from the source tree) --"
+# Same derivation, same direction (repo -> image), for the one part of systemd/
+# the unit globs cannot see. *.service/*.timer at the first level skips the
+# tmpfiles.d/ subdirectory entirely, so before this block the drop-in that
+# creates /run/litclock and /var/lib/litclock was checked by nothing at all —
+# not the derived unit check, not required_files, not tests/test_pi_gen.py.
+SRC_TMPFILES_DIR="${SRC_SYSTEMD_DIR}/tmpfiles.d"
+ETC_TMPFILES_DIR=/etc/tmpfiles.d
+
+# BEGIN tmpfiles-install-check (tests/test_pi_gen.py extracts between these sentinels)
+shopt -s nullglob
+src_tmpfiles=( "$SRC_TMPFILES_DIR"/*.conf )
+shopt -u nullglob
+# Same floor as 03-install-services. tests/test_pi_gen.py asserts the two values
+# stay equal, so they cannot drift apart.
+MIN_EXPECTED_TMPFILES=1
+if [ "${#src_tmpfiles[@]}" -lt "$MIN_EXPECTED_TMPFILES" ]; then
+    echo "FAIL: only ${#src_tmpfiles[@]} tmpfiles.d drop-ins in ${SRC_TMPFILES_DIR} — repo staging is broken"
     exit 1
 fi
-echo "  OK: expected units enabled, litclock.timer correctly deferred"
+for src in "${src_tmpfiles[@]}"; do
+    name=$(basename "$src")
+    if [ ! -e "${ETC_TMPFILES_DIR}/${name}" ]; then
+        echo "FAIL: ${name} exists in systemd/tmpfiles.d/ but was never installed to ${ETC_TMPFILES_DIR}/"
+        exit 1
+    fi
+    if ! cmp -s "$src" "${ETC_TMPFILES_DIR}/${name}"; then
+        echo "FAIL: ${ETC_TMPFILES_DIR}/${name} differs from the staged source ${src}"
+        exit 1
+    fi
+done
+# END tmpfiles-install-check
+echo "  OK: all ${#src_tmpfiles[@]} tmpfiles.d drop-in(s) installed to ${ETC_TMPFILES_DIR}/ and match the source"
+
+echo "-- Systemd enable symlinks (derived from [Install]) --"
+# Every unit carrying an [Install] section must have its .wants symlink, EXCEPT
+# the deliberate exclusions below. tests/test_pi_gen.py asserts this list stays
+# byte-identical to BUILD_ENABLE_EXCLUSIONS in 03-install-services/00-run.sh,
+# so the two cannot drift apart.
+#
+# litclock.timer — first-boot.sh enables it after setup completes. Enabling at
+# build time would race splash/firstboot for GPIO before setup is done, which
+# is why this is checked as a hard negative rather than merely skipped.
+SMOKE_ENABLE_EXCLUSIONS=(
+    litclock.timer
+)
+# BEGIN enable-symlink-check (tests/test_pi_gen.py extracts between these sentinels)
+#
+# This block verifies ENABLEMENT only — the .wants/.requires symlinks, which
+# exist only on a built image and so are the one thing pytest cannot see.
+#
+# Directive VALIDITY (does this [Install] section install anything at all?) was
+# briefly checked here as a hard failure and has been moved to
+# tests/test_pi_gen.py::TestInstallSectionValidity. Reason: a false positive in
+# this file blocks every release ~38 minutes into a 40-minute build, and the
+# hard-fail version had four separate ways to reject a legal unit — `UpheldBy=`
+# (valid since systemd 249) and `DefaultInstance=` were absent from its
+# allow-list, indented directives are legal because systemd strstrip()s every
+# line, and `WantedBy=a.target \` continuations parsed into a literal `\`
+# target. Validity is a property of a file in the repo, so it belongs in a
+# 0.3-second test that cannot block a build. Enablement needs the image.
+#
+# src_units is set by the unit-install-check block above. Asserted non-empty
+# here rather than assumed: an empty array makes every loop below a no-op and
+# this section would print its success line having verified nothing, which is
+# the cannot-fail-guard shape this file exists to remove. The harness injects
+# its own src_units, so without this assert the dependency is covered nowhere.
+if [ "${#src_units[@]}" -eq 0 ]; then
+    echo "FAIL: src_units is empty — the enable check would verify nothing and pass"
+    exit 1
+fi
+unverified=0
+for src in "${src_units[@]}"; do
+    name=$(basename "$src")
+    # Normalise leading whitespace ONCE, then match. systemd's parser
+    # strstrip()s every line, so `  [Install]` and `  WantedBy=x` are legal
+    # units. Column-0 anchors silently skipped the former — litclock-dev#547's own
+    # failure mode arriving through whitespace instead of a name list — and
+    # hard-failed the latter. Line continuations are joined in the same pass so
+    # `WantedBy=a.target \` + `b.target` yields both targets rather than a
+    # literal backslash.
+    #
+    # COMMENTS ARE DELETED BEFORE THE JOIN, and the order matters. systemd does
+    # NOT continue a comment line: a unit whose line above [Install] ends in a
+    # backslash is still enabled by `systemctl enable` (verified against a real
+    # --root tree). Joining it here produced `# comment [Install]`, so the grep
+    # below failed and the unit was skipped by this entire check with no output
+    # — the silent-skip this normalisation exists to close, reintroduced by the
+    # normalisation itself. Same bug one level in: a `# note \` INSIDE [Install]
+    # swallowed the following WantedBy= and downgraded the unit to a NOTE.
+    # TWO passes. `N` inside the :a loop appends the next RAW line without
+    # re-running the delete, so a single pass still joined a comment that
+    # FOLLOWS a continued directive: `WantedBy=a.target \` + `# note` became
+    # `WantedBy=a.target # note`, and the shipped check then hard-failed a unit
+    # real systemd enables fine. Comments must be gone before the join starts.
+    norm=$(tr -d '\r' < "$src" \
+        | sed -e 's/^[[:space:]]*//' -e '/^[#;]/d' \
+        | sed -e :a -e '/\\$/N; s/\\\n[[:space:]]*//; ta' \
+        | sed -e 's/[[:space:]]*\\[[:space:]]*$//')
+    printf '%s\n' "$norm" | grep -q '^\[Install\]' || continue
+
+    skip=false
+    for excluded in "${SMOKE_ENABLE_EXCLUSIONS[@]}"; do
+        if [ "$name" = "$excluded" ]; then
+            skip=true
+            break
+        fi
+    done
+    if [ "$skip" = true ]; then
+        # Every *.wants and *.requires directory, not a hardcoded pair — an
+        # excluded unit wanted by sockets.target or a custom target would
+        # otherwise pass while actually being enabled.
+        if compgen -G "${ETC_SYSTEMD_DIR}/*.wants/${name}" > /dev/null \
+            || compgen -G "${ETC_SYSTEMD_DIR}/*.requires/${name}" > /dev/null; then
+            echo "FAIL: ${name} is a deliberate build-time exclusion but was enabled:"
+            compgen -G "${ETC_SYSTEMD_DIR}/*.wants/${name}" || true
+            compgen -G "${ETC_SYSTEMD_DIR}/*.requires/${name}" || true
+            exit 1
+        fi
+        continue
+    fi
+
+    # Scope the read to the [Install] section — a stray or mistyped WantedBy=
+    # earlier in the file would otherwise win. Iterate EVERY target, since
+    # `WantedBy=a.target b.target` enables into both and checking only the
+    # first would half-verify it.
+    install_block=$(printf '%s\n' "$norm" | sed -n '/^\[Install\]/,/^\[/p')
+    wanted_by=$(printf '%s\n' "$install_block" \
+        | sed -n 's/^WantedBy[[:space:]]*=[[:space:]]*//p' \
+        | tr -s '[:space:]' ' ')
+    # RequiredBy= is verified the same way: it creates <target>.requires/<unit>,
+    # exactly as checkable as .wants/. It used to be lumped in with Alias= and
+    # Also= as "not verifiable", which would have let a future RequiredBy= unit
+    # ship un-enabled behind a NOTE — litclock-dev#547 surviving inside the check built
+    # to eliminate it.
+    required_by=$(printf '%s\n' "$install_block" \
+        | sed -n 's/^RequiredBy[[:space:]]*=[[:space:]]*//p' \
+        | tr -s '[:space:]' ' ')
+    if [ -z "${wanted_by// /}" ] && [ -z "${required_by// /}" ]; then
+        # An [Install] section with NO recognised directive at all installs
+        # nothing and is always a typo — the litclock-dev#547 shape. Hard-failed here as
+        # well as in pytest, deliberately belt-and-braces: pytest gates the build
+        # only via the workflow step added alongside this, and a gate that lives
+        # in exactly one place is how this went missing the first time.
+        #
+        # This is narrow enough to be safe now, which it was NOT when it was
+        # removed. All four of its false-positive causes are fixed above: the
+        # directive list is the FULL documented set (UpheldBy= and
+        # DefaultInstance= were missing), leading whitespace is stripped,
+        # continuations are joined, and comments are deleted before the join.
+        if ! printf '%s\n' "$install_block" \
+            | grep -qE '^(Alias|WantedBy|RequiredBy|UpheldBy|Also|DefaultInstance)[[:space:]]*=[[:space:]]*[^[:space:]]'; then
+            echo "FAIL: ${name} has an [Install] section with no recognised install directive"
+            echo "      That section installs nothing. Check for a typo (e.g. WnatedBy=)."
+            exit 1
+        fi
+        # Alias=, Also=, UpheldBy= and DefaultInstance= are legal but their
+        # enablement is not verifiable by the .wants/.requires convention.
+        echo "  NOTE: ${name} has [Install] but no WantedBy=/RequiredBy= — enablement not verified here"
+        unverified=$(( unverified + 1 ))
+        continue
+    fi
+    for target in $wanted_by; do
+        if [ ! -e "${ETC_SYSTEMD_DIR}/${target}.wants/${name}" ]; then
+            echo "FAIL: ${name} has [Install] WantedBy=${target} but no enable symlink was created"
+            exit 1
+        fi
+    done
+    for target in $required_by; do
+        if [ ! -e "${ETC_SYSTEMD_DIR}/${target}.requires/${name}" ]; then
+            echo "FAIL: ${name} has [Install] RequiredBy=${target} but no .requires symlink was created"
+            exit 1
+        fi
+    done
+done
+# Report the unverified count rather than claiming "every [Install] unit
+# enabled" unconditionally. The old line said that even when a NOTE had just
+# been printed, so a build log ended with a success claim that contradicted
+# the line above it. Inside the sentinels so the claim itself is tested.
+if [ "$unverified" -gt 0 ]; then
+    echo "  OK: every WantedBy= [Install] unit enabled, ${#SMOKE_ENABLE_EXCLUSIONS[@]} deliberate exclusion(s) verified un-enabled, ${unverified} unit(s) NOT verified (see NOTEs above)"
+else
+    echo "  OK: every [Install] unit enabled, ${#SMOKE_ENABLE_EXCLUSIONS[@]} deliberate exclusion(s) verified un-enabled"
+fi
+# END enable-symlink-check
 
 echo "-- Automatic OS updates disabled (appliance) --"
 # 02-configure-system masks the apt-daily timers and zeroes the periodic knobs
@@ -91,23 +336,88 @@ echo "  OK: apt-daily timers masked + all APT::Periodic knobs effectively zeroed
 echo "-- Systemd unit syntax --"
 # Running inside the target's own namespace — no --root quirks, no
 # cross-namespace symlink issues. Still tolerant of benign warnings.
-fatal_patterns='Failed to parse|is not a valid unit name|Bad unit file setting|Unknown lvalue|Unknown section|Assignment outside of section'
-for unit in litclock.service litclock.timer litclock-splash.service \
-            litclock-firstboot.service litclock-shutdown.service \
-            wifi-watchdog.service wifi-watchdog.timer; do
+# BEGIN unit-syntax-check (tests/test_pi_gen.py extracts between these sentinels)
+# The patterns live INSIDE the sentinels on purpose. Outside them the harness
+# ran with both unset, and `grep -qiE ""` matches every line — so the tests
+# would have exercised a classifier that calls everything fatal while the
+# shipped one classified nothing. Same outside-the-sentinel blind spot this PR
+# exists to close.
+# `Unknown key name` is the message that matters and it was missing. systemd has
+# emitted it since v246 (bookworm ships 252); `Unknown lvalue` is pre-246 wording
+# and is dead here, kept only so an older host still matches.
+#
+# THE EXIT CODE IS NOT A CLASSIFIER. Verified on systemd 255: a unit containing
+# `WnatedBy=multi-user.target` — the literal litclock-dev#547 typo this gate is named for —
+# produces `Unknown key name 'WnatedBy' in section 'Install', ignoring.` and exits
+# ZERO. So the old `if output=$(...); then :; else <classify>; fi` never reached
+# the classifier for it: no output echoed, neither pattern consulted, the counter
+# not incremented, and the success line printed. Output is now captured and
+# classified on EVERY run regardless of rc.
+fatal_patterns='Failed to parse|is not a valid unit name|Bad unit file setting|Unknown key name|Unknown lvalue|Unknown section|Assignment outside of section'
+# A SECOND fatal class, and the reason this loop is now load-bearing rather than
+# advisory. Widening it from 7 hardcoded units to the whole source tree means
+# systemd-analyze now resolves every ExecStart= in the tree — so it reports
+# "Command ... is not executable" or "No such file or directory" for a helper
+# that never reached the image. That is exactly the litclock-dev#547 evidence, and it was
+# being collected and then thrown away: the message matches none of the patterns
+# above, so the old code printed "(warnings only — not fatal)" and then "OK: all
+# unit files pass".
+#
+# It is reachable today. litclock-set-timezone, reset-setup.sh,
+# litclock-mark-collected.sh, litclock-wifi-reset.sh and the NM dispatcher are
+# all referenced by units and none of them appear in required_files, so nothing
+# else in this file would notice their absence. On the device it surfaces as
+# status=203/EXEC in a journal nobody reads on a keyboardless appliance.
+# Anchored to the message systemd actually emits, not the bare errno string.
+# `No such file or directory` on its own is generic: any chroot-level failure
+# carrying that errno (dbus, /proc, machine-id) would convert this from
+# advisory into a hard fail on EVERY unit, 38 minutes into a 40-minute build,
+# on the one gate whose false positives block all releases.
+exec_fatal_patterns='Command .* is not executable|Command .* No such file or directory'
+syntax_warned=0
+for src in "${src_units[@]}"; do
+    unit=$(basename "$src")
     echo "  checking $unit"
-    if output=$(systemd-analyze verify "$unit" 2>&1); then
-        :
-    else
+    # 2>&1 is load-bearing: systemd-analyze writes ALL diagnostics to stderr and
+    # nothing to stdout (verified on 255). Without it $output is always empty and
+    # this whole gate is a no-op.
+    #
+    # rc is captured SEPARATELY rather than discarded with `|| true`. Round 3
+    # replaced rc-gating with an output-emptiness test, which laundered a
+    # non-zero exit with no output into "OK: all unit files pass" — a
+    # cannot-fail guard introduced while fixing a cannot-fail guard. Reachable
+    # in the chroot: systemd-analyze under qemu-user-static binfmt dying on a
+    # signal exits 132/139 and prints nothing.
+    analyze_rc=0
+    output=$(systemd-analyze verify -- "$src" 2>&1) || analyze_rc=$?
+    if [ "$analyze_rc" -ne 0 ] && [ -z "$output" ]; then
+        echo "FAIL: systemd-analyze verify exited ${analyze_rc} for $unit with no output"
+        echo "      The verifier itself failed; this gate cannot vouch for the unit."
+        exit 1
+    fi
+    if [ -n "$output" ]; then
         echo "$output" | sed 's/^/    /'
         if echo "$output" | grep -qiE "$fatal_patterns"; then
             echo "FAIL: $unit has real errors"
             exit 1
         fi
+        if echo "$output" | grep -qiE "$exec_fatal_patterns"; then
+            echo "FAIL: $unit references a command that is missing or not executable in the image"
+            echo "      This is the litclock-dev#547 shape: the unit shipped, the thing it runs did not."
+            exit 1
+        fi
+        # Anything left is genuinely advisory, but it is COUNTED so the success
+        # line below cannot claim a clean pass over a unit that printed output.
         echo "    (warnings only — not fatal)"
+        syntax_warned=$(( syntax_warned + 1 ))
     fi
 done
-echo "  OK: all unit files pass"
+if [ "$syntax_warned" -gt 0 ]; then
+    echo "  OK: all unit files parse, ${syntax_warned} with non-fatal warnings (see above)"
+else
+    echo "  OK: all unit files pass"
+fi
+# END unit-syntax-check
 
 echo "-- Quote image corpus --"
 # Quote images are fetched from a GitHub Release during the build
@@ -145,13 +455,13 @@ echo "-- Python imports (venv, pure-Python deps) --"
 # imports (waveshare_epd, RPi.GPIO, spidev) are not checked here — they
 # require real hardware probing and are verified on real Pis.
 /home/pi/litclock/venv/bin/python3 -c '
-import astral, PIL, qrcode, requests, pytz, timezonefinder, urllib3, certifi
+import astral, PIL, qrcode, requests, timezonefinder, urllib3, certifi
 # Successful import is the pass signal. Version-print is informational and
 # must tolerate packages that do not expose __version__ at module level
 # (e.g. qrcode).
 def v(m): return getattr(m, "__version__", "unknown")
 print(f"  OK: astral={v(astral)}, PIL={v(PIL)}, qrcode={v(qrcode)}, "
-      f"requests={v(requests)}, pytz={v(pytz)}, tzf={v(timezonefinder)}, "
+      f"requests={v(requests)}, tzf={v(timezonefinder)}, "
       f"urllib3={v(urllib3)}, certifi={v(certifi)}")
 '
 

--- a/requirements.in
+++ b/requirements.in
@@ -38,7 +38,6 @@ gpiozero==2.0.1.post3
 lgpio==0.2.2.0
 pigpio==1.78
 pillow==12.3.0
-pytz==2026.3.post1
 qrcode==8.2
 requests==2.34.2
 spidev==3.8

--- a/requirements.txt
+++ b/requirements.txt
@@ -51,8 +51,6 @@ pillow==12.3.0
     # via -r requirements.in
 pycparser==3.0
     # via cffi
-pytz==2026.3.post1
-    # via -r requirements.in
 qrcode==8.2
     # via -r requirements.in
 requests==2.34.2

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -589,6 +589,45 @@ if [[ ${#REMOVED[@]} -gt 0 ]]; then
     log_info "Removed stale files: ${REMOVED[*]}"
 fi
 
+# litclock-dev#604 — invalidate the runtime-render validation marker when
+# any of its proof inputs changed in this update. The marker records that
+# `validate_measurement.py check --stamp` proved THIS freetype reproduces
+# THAT measurement dump with THESE fonts; it is gitignored, so the
+# git-reset above never touches it, and without this step a font change,
+# dump regen, freetype pin bump, or measurement-semantics change would
+# leave a stale proof in force. Removing it drops flag-enabled devices to
+# the pre-rendered tier until an operator re-runs check --stamp — a wrong
+# fallback is impossible, a wrong render is not.
+# The reader honors LITCLOCK_RUNTIME_VALIDATED_MARKER (set via env.sh,
+# which runtheclock.sh sources) — resolve the SAME path here or a relocated
+# marker silently survives the one invalidation layer that covers
+# semantics-only proof changes, where the digest recompute can't help
+# (litclock-dev#611 review). Subshell so env.sh can't mutate this script.
+RUNTIME_MARKER=$(
+    [[ -f "$INSTALL_DIR/env.sh" ]] && source "$INSTALL_DIR/env.sh" 2>/dev/null
+    echo "${LITCLOCK_RUNTIME_VALIDATED_MARKER:-$INSTALL_DIR/.runtime-render-validated}"
+)
+if [[ -f "$RUNTIME_MARKER" ]]; then
+    git diff --quiet "$OLD_SHA" "$NEW_SHA" -- \
+        fonts/ \
+        tools/gd-expected-measurements.json.gz \
+        requirements.txt \
+        src/quote_renderer.py \
+        src/gd_measure.py \
+        tools/validate_measurement.py 2>/dev/null
+    _marker_diff_rc=$?
+    if [[ "$_marker_diff_rc" -eq 1 ]]; then
+        rm -f "$RUNTIME_MARKER"
+        log_info "runtime-render validation marker removed: its proof inputs changed in this update (litclock-dev#604) — re-run tools/validate_measurement.py check --stamp to re-enable the runtime tier"
+    elif [[ "$_marker_diff_rc" -gt 1 ]]; then
+        # git diff itself failed (gc'd SHA, corrupt object) — we cannot
+        # PROVE the inputs are unchanged, and a wrong fallback beats a
+        # wrong render. Same action, honest log.
+        rm -f "$RUNTIME_MARKER"
+        log_info "runtime-render validation marker removed: could not verify its proof inputs across this update (git diff rc=$_marker_diff_rc) — re-run tools/validate_measurement.py check --stamp to re-enable the runtime tier"
+    fi
+fi
+
 # Remove old systemd units that no longer exist in the repo
 for installed_unit in /etc/systemd/system/litclock*.service \
                       /etc/systemd/system/litclock*.timer; do
@@ -766,7 +805,7 @@ elif ! grep -q "VIRTUAL_ENV=[\"']*$INSTALL_DIR/venv[\"']*$" "$INSTALL_DIR/venv/b
     rm -rf "$INSTALL_DIR/venv"
     python3 -m venv --system-site-packages "$INSTALL_DIR/venv"
     NEED_PIP=true
-elif ! "$PYTHON" -c "import PIL, pytz, requests" &>/dev/null 2>&1; then
+elif ! "$PYTHON" -c "import PIL, requests" &>/dev/null 2>&1; then
     log_warn "Virtual environment broken — recreating..."
     rm -rf "$INSTALL_DIR/venv"
     python3 -m venv --system-site-packages "$INSTALL_DIR/venv"
@@ -1016,7 +1055,7 @@ for unit in "$INSTALL_DIR"/systemd/*.service "$INSTALL_DIR"/systemd/*.timer; do
         continue
     fi
 
-    # firstboot service is managed by install.sh/reset-setup.sh — don't re-enable
+    # firstboot service is managed by the image build/reset-setup.sh — don't re-enable
     if [[ "$name" == "litclock-firstboot.service" ]]; then
         sudo cp "$unit" /etc/systemd/system/
         continue
@@ -1043,23 +1082,85 @@ for unit in "$INSTALL_DIR"/systemd/*.service "$INSTALL_DIR"/systemd/*.timer; do
         # state, which is the post-cp default for a freshly-installed unit
         # that has [Install].
         if systemctl is-enabled "$name" 2>/dev/null | grep -q "^disabled$"; then
-            sudo systemctl enable "$name"
-            ENABLED_UNITS+=("$name")
+            # Record only on SUCCESS. update.sh has no errexit by design, so a
+            # failed `systemctl enable` used to fall through and still append to
+            # ENABLED_UNITS — the run then logged "Newly enabled: <unit>", the
+            # summary reported it under "New services", and the OTA declared
+            # success with the unit still disabled. For a timer that is the
+            # brick-class outcome: nothing runs, nothing complains.
+            if sudo systemctl enable "$name"; then
+                ENABLED_UNITS+=("$name")
+            else
+                log_warn "failed to enable $name — it is installed but will NOT run"
+            fi
         fi
     fi
 done
 
 sudo systemctl daemon-reload
 
-# #241 — install tmpfiles.d entry for the tmpfs heartbeat dir and
-# materialize it now (avoids waiting until next boot). If --create
-# fails, /run/litclock won't exist on the running system and the
-# heartbeat will silently drop until the next reboot — log loudly so
-# operators see it in journalctl rather than silently swallowing.
-if [[ -f "$INSTALL_DIR/systemd/tmpfiles.d/litclock.conf" ]]; then
-    sudo cp "$INSTALL_DIR/systemd/tmpfiles.d/litclock.conf" /etc/tmpfiles.d/
-    sudo systemd-tmpfiles --create /etc/tmpfiles.d/litclock.conf \
-        || log_warn "systemd-tmpfiles --create failed — /run/litclock may not exist until reboot"
+# #241 — install tmpfiles.d drop-ins for the tmpfs heartbeat dir and the
+# /var/lib/litclock state dir, and materialize them now (avoids waiting until
+# next boot). If --create fails, /run/litclock won't exist on the running
+# system and the heartbeat will silently drop until the next reboot — log
+# loudly so operators see it in journalctl rather than silently swallowing.
+#
+# Globbed, like the unit loop above and like pi-gen's 03-install-services.
+# This was a hardcoded litclock.conf behind a soft `if [[ -f ]]`, which is
+# two bugs in three lines: a second drop-in would never reach a fielded Pi
+# via OTA, and a MISSING one skipped silently with no journal line at all.
+# litclock-dev#547 is the same shape one directory up.
+tmpfiles_installed=0
+tmpfiles_seen=0
+# Save and restore rather than blindly clearing: update.sh is 1400 lines and a
+# future `shopt -s nullglob` above this point would otherwise be switched off
+# here for every later phase.
+_ng_saved=$(shopt -p nullglob)
+shopt -s nullglob
+sudo install -d -m 0755 /etc/tmpfiles.d
+for conf in "$INSTALL_DIR"/systemd/tmpfiles.d/*.conf; do
+    tmpfiles_seen=$(( tmpfiles_seen + 1 ))
+    # Same regular-file requirement pi-gen's 03 uses. Catches ACCIDENTS — a
+    # stray symlink or a directory named *.conf — not a hostile pi user. This
+    # is a check-then-use on a pi-writable path, so the file can be swapped for
+    # a symlink between the test and the `sudo install` below; treating it as a
+    # privilege boundary would be wrong. It is not one here: the attacker would
+    # be the pi user, who already runs this script and (per the shipped
+    # 010_pi-nopasswd) already has full sudo. See the O_NOFOLLOW/O_NONBLOCK
+    # note in the project learnings for the shape a real boundary needs.
+    if [[ ! -f "$conf" || -L "$conf" ]]; then
+        log_warn "skipping $(basename "$conf") — not a regular file"
+        continue
+    fi
+    # `install -m 0644 -o root -g root`, not `cp`, matching 03-install-services.
+    # cp applies the SOURCE mode, so a drop-in committed 0755 or 0600 landed
+    # correctly on a flashed image and incorrectly on every OTA'd Pi — a
+    # divergence only reproducible on the fielded fleet, which is the one
+    # configuration QA never covers.
+    #
+    # The exit status is CHECKED and the counter only advances on success. It
+    # used to increment unconditionally, which meant: cp fails (read-only /etc,
+    # ENOSPC, EIO on a worn SD), the PREVIOUS release's drop-in is still present
+    # so `systemd-tmpfiles --create` succeeds against the stale file and its
+    # log_warn never fires, the counter reads 1 so the zero-drop-in warning
+    # never fires either, and the OTA reports success having installed nothing.
+    # That is the exact silent-swallow class this block was written to remove.
+    if ! sudo install -m 0644 -o root -g root "$conf" /etc/tmpfiles.d/; then
+        log_warn "failed to install $(basename "$conf") into /etc/tmpfiles.d/ — its rules were NOT refreshed"
+        continue
+    fi
+    sudo systemd-tmpfiles --create "/etc/tmpfiles.d/$(basename "$conf")" \
+        || log_warn "systemd-tmpfiles --create failed for $(basename "$conf") — its directories may not exist until reboot"
+    tmpfiles_installed=$(( tmpfiles_installed + 1 ))
+done
+eval "$_ng_saved"
+if [[ $tmpfiles_seen -eq 0 ]]; then
+    # Not fatal — the previously installed drop-ins are still in /etc and the
+    # clock keeps running off them. But it means this checkout is not what we
+    # think it is, and the old soft `if` reported nothing at all here.
+    log_warn "no tmpfiles.d drop-ins found under $INSTALL_DIR/systemd/tmpfiles.d/ — /run/litclock and /var/lib/litclock rules were not refreshed"
+elif [[ $tmpfiles_installed -ne $tmpfiles_seen ]]; then
+    log_warn "installed only ${tmpfiles_installed} of ${tmpfiles_seen} tmpfiles.d drop-ins — see warnings above"
 fi
 
 if [[ ${#ENABLED_UNITS[@]} -gt 0 ]]; then

--- a/tests/test_build_image_workflow.py
+++ b/tests/test_build_image_workflow.py
@@ -4,11 +4,16 @@ Validates workflow structure, triggers, and build configuration.
 """
 
 import os
+import re
 
 import yaml
 
 REPO_ROOT = os.path.join(os.path.dirname(__file__), "..")
 WORKFLOW_PATH = os.path.join(REPO_ROOT, ".github", "workflows", "build-image.yml")
+
+# Every spelling of "the SHA the workflow FILE came from". On a
+# workflow_dispatch that is master, not the litclock_ref that got checked out.
+UNTRUSTWORTHY_SHA = re.compile(r"GITHUB_SHA|github\.sha|github\.event\.[\w.]*\bsha\b")
 
 
 def _load_workflow():
@@ -19,6 +24,172 @@ def _load_workflow():
     if True in wf and "on" not in wf:
         wf["on"] = wf.pop(True)
     return wf
+
+
+def _step(name):
+    wf = _load_workflow()
+    for step in wf["jobs"]["build"]["steps"]:
+        if step.get("name") == name:
+            return step
+    raise AssertionError(f"{name} step not found in build-image.yml")
+
+
+def _strip_comments(script):
+    """Drop full-line shell comments.
+
+    Without this, commenting out `RESOLVED_SHA="$(git rev-parse ...)"` and
+    reverting the behaviour elsewhere left every assertion here green — the
+    positive check was satisfied by the corpse of the line it was guarding.
+    """
+    return "\n".join(ln for ln in script.splitlines() if not ln.strip().startswith("#"))
+
+
+def _step_text(name):
+    """Everything in a step that can set a value: `run` AND `env`.
+
+    Reading only `run` was defeatable: a new `env:` entry could reintroduce
+    GITHUB_SHA with the whole suite green, because nothing ever looked there.
+    """
+    step = _step(name)
+    env = step.get("env") or {}
+    return _strip_comments(step.get("run", "")) + "\n" + "\n".join(f"{k}={v}" for k, v in env.items())
+
+
+def _version_step_script():
+    """The `run:` body of the Determine version step, comments stripped."""
+    return _strip_comments(_step("Determine version")["run"])
+
+
+class TestVersionStampProvenance:
+    """The version/SHA stamp must describe the code actually built.
+
+    On workflow_dispatch, GITHUB_SHA is the SHA of the ref the workflow FILE
+    came from (master), not the litclock_ref that got checked out. Using it
+    stamped dev images of a feature branch with master's SHA, in both the
+    release asset name and the git_sha= line of /etc/litclock-version — so a QA
+    artifact could not be traced to the code inside it.
+    """
+
+    def test_sha_comes_from_the_checked_out_head(self):
+        script = _version_step_script()
+        assert "git rev-parse HEAD" in script, (
+            "the version stamp must resolve HEAD after checkout, not trust GITHUB_SHA"
+        )
+        assert "--short" not in script, (
+            "`git rev-parse --short=7` returns a MINIMUM of 7 chars and lengthens on collision "
+            "or with core.abbrev set; slice the full SHA instead so the tag and asset name are deterministic"
+        )
+
+    def test_github_sha_is_not_used_for_the_stamp(self):
+        offenders = [ln.strip() for ln in _step_text("Determine version").splitlines() if UNTRUSTWORTHY_SHA.search(ln)]
+        assert not offenders, (
+            f"the workflow-file SHA was reintroduced into the version stamp: {offenders}. "
+            f"On workflow_dispatch it is master's SHA, not the checked-out ref."
+        )
+
+    def test_resolved_shas_are_assigned_exactly_once(self):
+        """The negative check above scans for a known-bad token, so it cannot
+        see a REASSIGNMENT that launders the same value through a different
+        expression. Verified defeat: appending a second
+        `RESOLVED_SHA="$(git rev-parse --short=7 origin/master)"` restored the
+        bug with the whole suite green. Pin the count instead."""
+        script = _version_step_script()
+        for var, expected in (
+            ("RESOLVED_SHA", 'RESOLVED_SHA="${RESOLVED_FULL_SHA:0:7}"'),
+            ("RESOLVED_FULL_SHA", 'RESOLVED_FULL_SHA="$(git rev-parse HEAD)"'),
+        ):
+            # `export`/`declare`/`readonly`/`+=` are the same defeat one keyword
+            # wider than the bare reassignment the docstring describes.
+            assigns = re.findall(rf"^\s*(?:export\s+|declare\s+-\w+\s+|readonly\s+)?{var}\+?=.*$", script, re.MULTILINE)
+            assert len(assigns) == 1, f"{var} is assigned {len(assigns)} times: {assigns}. Exactly one is safe."
+            assert assigns[0].strip() == expected, f"{var} no longer resolves the checked-out HEAD: {assigns[0]!r}"
+
+    def test_full_sha_is_published_and_is_not_the_short_form(self):
+        """`gh release create --target` takes a branch name or a FULL commit
+        SHA; a 7-char abbreviation is not guaranteed to resolve. The two
+        outputs must stay distinct, or --target silently gets the short one."""
+        script = _version_step_script()
+        assert 'echo "full_sha=${RESOLVED_FULL_SHA}"' in script, "full_sha is not published as a step output"
+        assert 'echo "sha=${RESOLVED_SHA}"' in script, "sha is not published as a step output"
+        assert "--short" not in re.search(r"^\s*RESOLVED_FULL_SHA=.*$", script, re.MULTILINE).group(0), (
+            "RESOLVED_FULL_SHA must not be abbreviated — --target needs the full SHA"
+        )
+
+    def test_checkout_precedes_the_version_step(self):
+        """git rev-parse only resolves the right commit if checkout ran first."""
+        steps = _load_workflow()["jobs"]["build"]["steps"]
+        checkout = next(i for i, s in enumerate(steps) if "actions/checkout" in str(s.get("uses", "")))
+        version = next(i for i, s in enumerate(steps) if s.get("name") == "Determine version")
+        assert checkout < version, "Determine version must run AFTER checkout or HEAD is not yet the target ref"
+
+    def test_checkout_actually_fetches_the_dispatch_ref(self):
+        """Ordering is not enough — the whole fix rests on HEAD being the
+        dispatched ref, which is the checkout step's `with: ref:`.
+
+        Verified defeat: deleting that `with:` block entirely left all workflow
+        tests green while HEAD silently reverted to master on workflow_dispatch,
+        fully restoring the bug this PR fixed. The same deletion drops
+        `submodules: true`, which is the lib/e-Paper driver — an image that
+        boots, serves the PWA, and never paints a quote.
+        """
+        steps = _load_workflow()["jobs"]["build"]["steps"]
+        checkout = next(s for s in steps if "actions/checkout" in str(s.get("uses", "")))
+        with_block = checkout.get("with") or {}
+        assert with_block.get("ref") == "${{ github.event.inputs.litclock_ref || github.ref }}", (
+            f"checkout no longer resolves the dispatch ref: {with_block.get('ref')!r}"
+        )
+        assert with_block.get("submodules") is True, (
+            "checkout lost `submodules: true` — the waveshare driver lives in the lib/e-Paper submodule"
+        )
+
+    def test_the_image_sha_stamp_comes_from_the_resolved_short_sha(self):
+        """LITCLOCK_SHA is the line that produces `git_sha=` in
+        /etc/litclock-version — the exact field this PR's rationale names as
+        having been mislabelled. Repointing it at outputs.ref (a branch name) or
+        outputs.version survived green, reintroducing an untraceable QA
+        artifact."""
+        step = _step("Configure pi-gen")
+        run = _strip_comments(step["run"])
+        env = step.get("env") or {}
+        assigns = re.findall(r"^\s*echo\s+\"LITCLOCK_SHA=([^\"]*)\"", run, re.MULTILINE)
+        assert len(assigns) == 1, f"LITCLOCK_SHA is written {len(assigns)} times: {assigns}"
+        var = re.fullmatch(r"\$\{(\w+)\}", assigns[0])
+        assert var, f"LITCLOCK_SHA={assigns[0]!r}; expected a shell variable bound via env:"
+        assert env.get(var.group(1)) == "${{ steps.version.outputs.sha }}", (
+            f"LITCLOCK_SHA resolves to {env.get(var.group(1))!r}, not the resolved short SHA"
+        )
+
+    def test_dispatch_input_never_reaches_a_shell_string_inline(self):
+        """`${{ }}` is spliced in before bash parses the line, so an input of
+        `master$(...)` executes. Every step that consumes the dispatch ref must
+        take it through `env:` and reference a quoted shell variable.
+
+        The runner holds contents:write, id-token:write and attestations:write,
+        so this reaches all the way to signing and publishing a release image.
+        """
+        offenders = []
+        for step in _load_workflow()["jobs"]["build"]["steps"]:
+            run = step.get("run")
+            if not run:
+                continue
+            for hit in re.findall(r"\$\{\{\s*([^}]+?)\s*\}\}", _strip_comments(run)):
+                # Any ref- or input-derived value, not just the two spellings
+                # that were being abused. Scoping this to `inputs`/`outputs.ref`
+                # quietly blessed the sinks left behind: outputs.version is
+                # github.ref_name with a leading v stripped on the tag path, and
+                # it flows on into outputs.img. Same sink class, one hop later.
+                if re.search(r"\binputs\b|outputs\.(ref|version|img|sha)\b|github\.ref_name", hit):
+                    offenders.append(f"{step.get('name', '?')}: {hit}")
+        assert not offenders, (
+            f"dispatch-derived values interpolated directly into a shell script: {offenders}. "
+            f'Pass them through the step\'s env: block and reference "$VAR".'
+        )
+
+    def test_dev_prefix_preserved(self):
+        """`dev-` is load-bearing: the stale-release cleanup selects on it, and
+        the OTA resolver filters tags to vMAJOR.MINOR.PATCH so dev tags stay
+        invisible to fielded clocks."""
+        assert 'VERSION="dev-$(date +%Y%m%d)-' in _version_step_script()
 
 
 class TestWorkflowTriggers:
@@ -92,3 +263,173 @@ class TestWorkflowBuildJob:
         assert dev_step["if"] == "github.ref_type != 'tag'"
         assert "gh release create" in dev_step["run"]
         assert "--prerelease" in dev_step["run"]
+
+
+class TestBuildIsGatedOnTests:
+    """The build workflow must actually run the image-correctness tests.
+
+    This is a single `build` job with no `needs:`, so for a while it ran no
+    tests at all — which meant moving the [Install]-validity check out of
+    05-smoke-test and into pytest quietly moved it off the release path
+    entirely. A `WnatedBy=` typo would have shipped on a tag push.
+    """
+
+    def _steps(self):
+        return _load_workflow()["jobs"]["build"]["steps"]
+
+    def test_pytest_runs_during_the_build(self):
+        runs = " ".join(s.get("run", "") for s in self._steps())
+        assert "pytest" in runs, "the build workflow runs no tests; pytest-side gates do not gate anything"
+        assert "tests/test_pi_gen.py" in runs, (
+            "the build does not run tests/test_pi_gen.py, which is the image-correctness gate"
+        )
+
+    def test_the_test_step_can_actually_fail_the_build(self):
+        """Substring checks are satisfied by the TEXT of the command, not its
+        effect. Verified: appending `|| true` to the pytest line left this class
+        green while the step could no longer fail anything — and this step is the
+        only thing putting TestInstallSectionValidity back on the release path.
+        `continue-on-error: true`, `if: false`, and a narrowing `-k` all defeat
+        it identically."""
+        step = next(s for s in self._steps() if "-m pytest" in s.get("run", ""))
+        assert not step.get("continue-on-error"), "the test step is continue-on-error; it cannot fail the build"
+        assert "if" not in step, f"the test step is conditional (if: {step.get('if')!r}); it may be skipped"
+        run = step["run"]
+        # `-m pytest`, not `pytest`: the step also pip-installs pytest, and
+        # matching the install line meant `|| true` on the actual invocation
+        # went unchecked. Verified defeat.
+        pytest_line = next(ln for ln in run.splitlines() if "-m pytest" in ln)
+        for swallow in ("|| true", "|| :", "|| echo", "; true"):
+            assert swallow not in pytest_line, f"pytest failure is swallowed by {swallow!r}"
+        assert "set +e" not in run, "set +e disables failure propagation in the test step"
+        for narrowing in (" -k ", "--deselect", "--ignore"):
+            assert narrowing not in pytest_line, (
+                f"the test step narrows its selection with {narrowing!r}; the gate may skip the validity test"
+            )
+
+    def test_the_test_step_runs_before_the_expensive_build(self):
+        """A broken tree must fail in ~1 minute, not at minute 38 of a 40-minute
+        build."""
+        names = [s.get("name", "") for s in self._steps()]
+        runs = [s.get("run", "") for s in self._steps()]
+        test_idx = next(i for i, r in enumerate(runs) if "pytest" in r)
+        build_idx = next(i for i, n in enumerate(names) if n == "Build image")
+        assert test_idx < build_idx, (
+            f"test step (index {test_idx}) runs after Build image (index {build_idx})"
+        )
+
+
+class TestReleaseTargetCommitish:
+    """Both release steps must stamp target_commitish with the SHA that was
+    actually built.
+
+    The dev step is the one that was wrong: it runs on `github.ref_type !=
+    'tag'`, i.e. exactly the workflow_dispatch path, where github.sha is the
+    SHA of the ref the workflow FILE came from. So a dev build produced an
+    image stamped with the right branch SHA and a Release pointing at master.
+    The tag step happened to be correct — on a tag push the two SHAs coincide —
+    but it is held to the same rule so there is one rule rather than two and a
+    footnote about which path each is safe on.
+    """
+
+    RELEASE_STEPS = ("Upload dev build", "Create release")
+
+    def test_both_release_steps_target_the_resolved_full_sha(self):
+        """Resolves through `env:`.
+
+        The values are passed via env rather than spliced inline with `${{ }}`,
+        because a neighbouring interpolation in the same string carried the
+        dispatch input and was a shell-injection sink. So the assertion has to
+        follow both hops: the --target argument must be a shell variable, and
+        that variable's env entry must bind to the resolved full SHA.
+        """
+        for name in self.RELEASE_STEPS:
+            step = _step(name)
+            env = step.get("env") or {}
+            run = _strip_comments(step["run"])
+            targets = re.findall(r"--target\s+\"([^\"]+)\"", run)
+            assert targets, f"{name} does not pass --target; GitHub would store the default branch name"
+            for t in targets:
+                var = re.fullmatch(r"\$\{(\w+)\}", t)
+                assert var, f"{name} targets {t!r}; expected a shell variable bound via env:"
+                bound = env.get(var.group(1))
+                assert bound == "${{ steps.version.outputs.full_sha }}", (
+                    f"{name}: env {var.group(1)} is {bound!r}, not the resolved full SHA"
+                )
+
+    def test_no_release_step_uses_the_workflow_file_sha(self):
+        for name in self.RELEASE_STEPS:
+            offenders = [ln.strip() for ln in _step_text(name).splitlines() if UNTRUSTWORTHY_SHA.search(ln)]
+            assert not offenders, f"{name} reintroduced the workflow-file SHA: {offenders}"
+
+    def test_the_workflow_never_references_github_sha_anywhere(self):
+        """The broadest form of the guard, and the one that would have caught
+        the missed instance: `7dcfc182` fixed the version stamp and left
+        `--target ${{ github.sha }}` in the dev step untouched, because every
+        assertion was scoped to a single step. Nothing in this workflow has a
+        legitimate use for github.sha — the checked-out HEAD is always the
+        honest answer. If one ever appears, this test is the place to justify
+        it explicitly rather than let it in silently."""
+        with open(WORKFLOW_PATH) as f:
+            lines = f.read().splitlines()
+        offenders = [ln.strip() for ln in lines if not ln.strip().startswith("#") and UNTRUSTWORTHY_SHA.search(ln)]
+        assert not offenders, (
+            f"github.sha / GITHUB_SHA used in build-image.yml: {offenders}. On workflow_dispatch it is "
+            f"the SHA of the ref the workflow FILE came from, not the code being built."
+        )
+
+
+class TestCheckoutDoesNotShipCredentials:
+    """litclock-dev#551 — the build copies the working tree (.git included) into the
+    image rootfs, so checkout must not persist the job token into .git/config.
+
+    `cp -a .` runs mid-job, before actions/checkout's post-step credential
+    cleanup, and nothing strips .git afterwards. `.git` is deliberately kept
+    (README Option 2 documents /home/pi/litclock as a build-from-source
+    checkout), so the fix is to never write the credential.
+    """
+
+    def test_checkout_sets_persist_credentials_false(self):
+        wf = _load_workflow()
+        checkouts = [
+            s
+            for s in wf["jobs"]["build"]["steps"]
+            if isinstance(s.get("uses"), str) and s["uses"].startswith("actions/checkout@")
+        ]
+        assert checkouts, "no actions/checkout step found in build-image.yml"
+        for step in checkouts:
+            with_block = step.get("with") or {}
+            assert "persist-credentials" in with_block, (
+                "actions/checkout must set persist-credentials — the tree "
+                "(including .git) is copied into the image rootfs (litclock-dev#551)"
+            )
+            value = with_block["persist-credentials"]
+            # PyYAML gives a bool for `false`; accept the string spelling too.
+            assert value is False or str(value).strip().lower() == "false", (
+                f"persist-credentials must be false, got {value!r}"
+            )
+
+    def test_tree_copy_still_happens_after_checkout(self):
+        """Anchors WHY the above matters. If the copy step is ever removed or
+        renamed, this test should be revisited rather than silently passing."""
+        wf = _load_workflow()
+        scripts = " ".join(
+            s.get("run", "") for s in wf["jobs"]["build"]["steps"] if isinstance(s.get("run"), str)
+        )
+        assert "cp -a . /tmp/pi-gen/litclock-src" in scripts, (
+            "the tree-copy step changed — re-check whether .git still reaches "
+            "the image rootfs (litclock-dev#551)"
+        )
+
+    def test_no_step_strips_dot_git_so_the_guard_is_load_bearing(self):
+        """If someone later strips .git from the staged tree, persist-credentials
+        stops being the only defence and this suite should say so."""
+        wf = _load_workflow()
+        scripts = " ".join(
+            s.get("run", "") for s in wf["jobs"]["build"]["steps"] if isinstance(s.get("run"), str)
+        )
+        strips = re.search(r"rm -rf\s+[^\s]*litclock-src/\.git\b", scripts)
+        assert not strips, (
+            "a step now strips .git from the staged tree — persist-credentials "
+            "is no longer the sole defence; update litclock-dev#551's reasoning"
+        )

--- a/tests/test_literary_clock_dry_run.py
+++ b/tests/test_literary_clock_dry_run.py
@@ -23,21 +23,20 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 LITERARY_CLOCK = REPO_ROOT / "src" / "literary_clock.py"
 
 # These tests subprocess out to `sys.executable -m src.literary_clock`. CI
-# installs PIL/pytz/requests into the same interpreter via
+# installs PIL/requests into the same interpreter via
 # `pip install -r requirements.txt`, so subprocess runs have the deps. On a
 # dev machine where pytest runs under the bare system python without deps,
 # skip — activating the venv (`./venv/bin/python -m pytest`) runs these.
 _HAS_CLOCK_DEPS = True
 try:
     import PIL  # noqa: F401
-    import pytz  # noqa: F401
     import requests  # noqa: F401
 except ImportError:
     _HAS_CLOCK_DEPS = False
 
 pytestmark = pytest.mark.skipif(
     not _HAS_CLOCK_DEPS,
-    reason="literary_clock deps (PIL/pytz/requests) not installed in the current interpreter",
+    reason="literary_clock deps (PIL/requests) not installed in the current interpreter",
 )
 
 

--- a/tests/test_pi_gen.py
+++ b/tests/test_pi_gen.py
@@ -1,12 +1,14 @@
 """Tests for the pi-gen custom stage.
 
-Validates that the stage structure is correct, the package list stays
-self-consistent, and build configuration is consistent.
+Validates that the stage structure is correct, packages are well-formed,
+and build configuration is consistent.
 """
 
 import os
 import re
+import shlex
 import stat
+import subprocess
 
 import pytest
 
@@ -58,18 +60,11 @@ class TestStageStructure:
 # ── Package list is self-describing ──────────────────────────────────
 
 
-def _strip_comments(body):
-    """Drop full-line shell comments so text assertions cannot be satisfied by
-    commented-out code. Without this, `# cp "${INSTALL_DIR}/systemd/x.service"`
-    would look identical to the real thing to a substring search."""
-    return "\n".join(line for line in body.splitlines() if not line.lstrip().startswith("#"))
-
-
 class TestPackageList:
     """pi-gen's 00-packages was previously cross-checked against
     scripts/install.sh, both directions. That guard died with install.sh
-    (litclock-dev#547): with one install path there is no second list to drift
-    from, so "parity" has nothing to compare against.
+    (litclock-dev#547): with one install path there is no second list to drift from,
+    so "parity" has nothing to compare against.
 
     What survives is the invariant that actually mattered — the apt-provisioned
     GPIO/SPI packages must stay in lockstep with requirements-apt.txt, which is
@@ -121,6 +116,24 @@ class TestPackageList:
         "wireless-tools",
         # jq — M5 status-file helper needs it for atomic JSON writes.
         "jq",
+        # litclock-dev#605 item 18 (Codex, #45 port review): the old
+        # install.sh parity diff covered the packages below too; the pinned
+        # floor replacing it did not, so deleting any of them stayed green.
+        # (item 18 also proposed qrencode, but its stated why — "renders the
+        # setup/handoff QRs" — is false: every QR is drawn by the pip
+        # `qrcode` library, and nothing invokes the qrencode binary.
+        # Deliberately NOT pinned; it is a removal candidate — see the litclock-dev#605
+        # thread. If removed, docs/building-image.md's package inventory
+        # line must drop it too.)
+        # Secondary Pillow build deps. The primary four above are what the
+        # import needs today; these are what pip compiles AGAINST when a
+        # Pillow bump rebuilds the wheel on-device (update.sh venv path) —
+        # absent, the rebuild silently drops the corresponding features.
+        "liblcms2-dev",
+        "libwebp-dev",
+        "libharfbuzz-dev",
+        "libfribidi-dev",
+        "libxcb1-dev",
     }
 
     def test_required_packages_are_present(self):
@@ -187,11 +200,10 @@ class TestConfig:
 
 class TestBCM2835:
     """Previously cross-checked against scripts/install.sh. With install.sh
-    retired (litclock-dev#547) pi-gen is the sole definer, so there is no
-    second value to disagree with. What is still worth asserting is that the
-    version is declared at all and is a plausible version string — a silently
-    empty BCM2835_VERSION would build an image whose e-ink driver never
-    links."""
+    retired (litclock-dev#547) pi-gen is the sole definer, so there is no second value
+    to disagree with. What is still worth asserting is that the version is
+    declared at all and is a plausible version string — a silently empty
+    BCM2835_VERSION would build an image whose e-ink driver never links."""
 
     def test_version_is_declared_and_well_formed(self):
         chroot_sh = os.path.join(STAGE_DIR, "00-install-deps", "01-run.sh")
@@ -205,117 +217,1459 @@ class TestBCM2835:
 # ── Systemd units referenced in stage match repo ─────────────────────
 
 
+SYSTEMD_DIR = os.path.join(REPO_ROOT, "systemd")
+INSTALL_SERVICES_SH = os.path.join(STAGE_DIR, "03-install-services", "00-run.sh")
+SMOKE_TEST_SH = os.path.join(STAGE_DIR, "05-smoke-test", "00-run.sh")
+
+
+UNIT_SUFFIXES = (".service", ".timer")
+
+# systemd/ subdirectories that the stage scripts know how to install. A new one
+# would be invisible to every glob in 03 and 05 at once — see
+# test_systemd_subdirectories_are_all_installed below.
+TMPFILES_DIR = os.path.join(SYSTEMD_DIR, "tmpfiles.d")
+KNOWN_SYSTEMD_SUBDIRS = {"tmpfiles.d"}
+
+
+# systemd strstrip()s every line, so `  [Install]` and `  WantedBy=x` are legal.
+# Column-0 anchors are blind to that, which made an indented [Install] invisible
+# to BOTH the shell check and this file — litclock-dev#547's failure mode arriving through
+# whitespace instead of a name list, with no second opinion.
+_INSTALL_HEADER_RE = re.compile(r"^[ \t]*\[Install\]", re.MULTILINE)
+# The full documented [Install] directive set. Not a curated subset: an
+# allow-list of directive NAMES is the same enumeration bug as a list of unit
+# names, one level down. UpheldBy= is valid since systemd 249.
+INSTALL_DIRECTIVES = ("Alias", "WantedBy", "RequiredBy", "UpheldBy", "Also", "DefaultInstance")
+_INSTALL_DIRECTIVE_RE = re.compile(rf"^[ \t]*(?:{'|'.join(INSTALL_DIRECTIVES)})[ \t]*=[ \t]*\S", re.MULTILINE)
+
+
+def _shell_floor(path, var="MIN_EXPECTED_UNITS"):
+    """Read a MIN_EXPECTED_* floor out of a stage script.
+
+    Asserts EXACTLY ONE assignment. `re.search` returns the first match, but a
+    plain shell variable is governed by the LAST assignment — so a second one
+    added later would drive the running guard while this kept reporting the old
+    value, green. Same defeat that
+    test_resolved_shas_are_assigned_exactly_once closes for the workflow.
+    """
+    body = open(path).read()
+    matches = re.findall(rf"^{re.escape(var)}=(\d+)$", body, re.MULTILINE)
+    assert matches, f"{var} not found in {path}"
+    assert len(matches) == 1, (
+        f"{var} is assigned {len(matches)} times in {path}: {matches}. "
+        f"The last assignment wins at runtime; this reader would report the first."
+    )
+    return int(matches[0])
+
+
+def _strip_comments(body):
+    """Drop full-line shell comments so text assertions cannot be satisfied by
+    commented-out code. Without this, `# cp "${INSTALL_DIR}/systemd/x.service"`
+    would look identical to the real thing to a substring search."""
+    return "\n".join(line for line in body.splitlines() if not line.lstrip().startswith("#"))
+
+
+def _repo_units():
+    """Every first-level unit file in systemd/, derived from disk.
+
+    Derived on purpose. Three hand-maintained lists (this file, the
+    03-install-services cp block, and the 05-smoke-test required_files array)
+    all drifted together and let litclock-reresolve-location.service reach no
+    flashed image at all (litclock-dev#547). A literal list here would be the fourth.
+
+    The floor is load-bearing, not decorative. Every guard below derives its
+    expected set from this function, so if the derivation ever collapses to []
+    (wrong path, renamed directory, changed suffix) those guards would assert
+    over an empty collection and pass GREEN with zero real assertions. That is
+    the same vacuous-pass failure the shell-side MIN_EXPECTED_UNITS exists to
+    prevent, and it was verified reachable: emptying systemd/ left 8 of the 10
+    systemd tests passing before this assert was added.
+    """
+    units = sorted(f for f in os.listdir(SYSTEMD_DIR) if f.endswith(UNIT_SUFFIXES))
+    floor = _shell_floor(INSTALL_SERVICES_SH)
+    assert len(units) >= floor, (
+        f"systemd/ derivation collapsed to {len(units)} units (floor {floor}). "
+        f"Every derived guard in this file would otherwise pass vacuously."
+    )
+    return units
+
+
+def _repo_tmpfiles():
+    """Every systemd-tmpfiles drop-in in systemd/tmpfiles.d/, derived from disk.
+
+    Derived for the same reason _repo_units() is, and with the same vacuous-pass
+    guard: if the derivation collapses to [] the checks below would assert over
+    an empty collection and pass green.
+    """
+    confs = sorted(f for f in os.listdir(TMPFILES_DIR) if f.endswith(".conf"))
+    floor = _shell_floor(INSTALL_SERVICES_SH, "MIN_EXPECTED_TMPFILES")
+    assert len(confs) >= floor, f"systemd/tmpfiles.d/ derivation collapsed to {len(confs)} drop-ins (floor {floor})."
+    return confs
+
+
+def _units_with_install_section():
+    out = []
+    for name in _repo_units():
+        with open(os.path.join(SYSTEMD_DIR, name)) as f:
+            if _INSTALL_HEADER_RE.search(f.read()):
+                out.append(name)
+    return out
+
+
+def _normalise_unit_body(text):
+    """Normalise a unit file the way systemd's parser sees it.
+
+    Comments are stripped BEFORE continuations are joined, and the order is the
+    whole point: systemd does not continue a comment line. Joining first made a
+    unit whose comment above [Install] ends in a backslash look like
+    `# comment [Install]` — so this file rejected a unit real systemd enables,
+    while 05-smoke-test silently SKIPPED the same unit. Two normalisers, two
+    different wrong answers, neither matching systemd.
+
+    Kept as a module-level function so it can be tested against those bodies
+    directly rather than only through the repo's own (currently comment-free)
+    units.
+    """
+    text = text.replace("\r\n", "\n")
+    # Comments first, then join, then drop any dangling backslash left when the
+    # line a continuation pointed at was itself a comment. 05-smoke-test does the
+    # same three passes; they must agree with each other and with systemd.
+    text = re.sub(r"(?m)^[ \t]*[#;].*$", "", text)
+    text = re.sub(r"\\\n[ \t]*", " ", text)
+    return re.sub(r"(?m)[ \t]*\\[ \t]*$", "", text)
+
+
+class TestInstallSectionValidity:
+    """An [Install] section must actually install something.
+
+    This lived briefly in 05-smoke-test as a hard failure and was moved here.
+    It is a property of a file in the repo, so a 0.3-second test can prove it;
+    in the smoke test a false positive blocks every release ~38 minutes into a
+    40-minute build, and the hard-fail version had four ways to reject a legal
+    unit (UpheldBy=, DefaultInstance=, indented directives, and
+    `WantedBy=a \\` continuations). Enablement still belongs in the smoke test —
+    only a built image has the .wants symlinks.
+    """
+
+    def test_every_install_section_carries_a_real_directive(self):
+        """The litclock-dev#547 case this is really for: typo `WnatedBy=` on
+        litclock-reresolve-location.service and the section installs nothing."""
+        bad = []
+        for name in _units_with_install_section():
+            with open(os.path.join(SYSTEMD_DIR, name)) as f:
+                body = _normalise_unit_body(f.read())
+            install_block = body[_INSTALL_HEADER_RE.search(body).start() :]
+            # Stop at the next section header, if any.
+            nxt = re.search(r"^[ \t]*\[(?!Install\])", install_block[1:], re.MULTILINE)
+            if nxt:
+                install_block = install_block[: nxt.start() + 1]
+            if not _INSTALL_DIRECTIVE_RE.search(install_block):
+                bad.append(name)
+        assert not bad, (
+            f"units carry an [Install] section with none of {INSTALL_DIRECTIVES}: {bad}. "
+            f"That section installs nothing — fix the directive or drop the section."
+        )
+
+    def test_normaliser_does_not_continue_a_comment_line(self):
+        """systemd does not treat a trailing backslash on a COMMENT as a
+        continuation. Verified against a real `systemctl --root=` tree: such a
+        unit is enabled normally. If the join runs first, [Install] disappears
+        into the comment."""
+        body = "[Unit]\nDescription=x\n# trailing comment continuation \\\n[Install]\nWantedBy=multi-user.target\n"
+        norm = _normalise_unit_body(body)
+        assert _INSTALL_HEADER_RE.search(norm), f"[Install] was swallowed by a comment continuation: {norm!r}"
+        assert _INSTALL_DIRECTIVE_RE.search(norm), "WantedBy= lost"
+
+    def test_normaliser_does_not_let_a_comment_eat_the_next_directive(self):
+        """Same bug one level in: `# note \\` INSIDE [Install] swallowed the
+        WantedBy= line below it."""
+        body = "[Unit]\nDescription=x\n[Install]\n# note \\\nWantedBy=multi-user.target\n"
+        norm = _normalise_unit_body(body)
+        assert _INSTALL_DIRECTIVE_RE.search(norm), f"WantedBy= eaten by the comment: {norm!r}"
+
+    def test_a_comment_after_a_continuation_does_not_become_a_target(self):
+        """`WantedBy=a.target \\` followed by a COMMENT. Real systemd enables into
+        a.target only. One pass left `a.target # comment`; stripping comments
+        first still left a dangling `\\` that iterated as a bogus target."""
+        body = "[Install]\nWantedBy=multi-user.target \\\n# trailing comment\n"
+        norm = _normalise_unit_body(body)
+        targets = re.search(r"^WantedBy[ \t]*=[ \t]*(.*)$", norm, re.MULTILINE).group(1).split()
+        assert targets == ["multi-user.target"], f"parsed targets {targets}"
+
+    def test_a_trailing_backslash_at_eof_is_not_a_target(self):
+        """A unit whose last line ends in a backslash with no newline after it.
+        The join pass needs a following newline to match, so without the final
+        cleanup the bare `\\` survives and iterates as a bogus target — the
+        shell side hits the same shape via sed's `N` at EOF."""
+        body = "[Install]\nWantedBy=multi-user.target \\"
+        norm = _normalise_unit_body(body)
+        targets = re.search(r"^WantedBy[ \t]*=[ \t]*(.*)$", norm, re.MULTILINE).group(1).split()
+        assert targets == ["multi-user.target"], f"parsed targets {targets}"
+
+    def test_normaliser_still_joins_real_continuations(self):
+        """The comment fix must not break the case the join exists for."""
+        body = "[Install]\nWantedBy=multi-user.target \\\n         graphical.target\n"
+        # Whitespace-tolerant: the join can leave a double space (the space
+        # before the backslash plus the joined one). Every consumer splits on
+        # whitespace, so the property is "both targets present and separated",
+        # not "exactly one space".
+        assert re.search(r"multi-user\.target\s+graphical\.target", _normalise_unit_body(body))
+
+    def test_directive_list_covers_what_the_smoke_test_verifies(self):
+        """The smoke test verifies WantedBy= and RequiredBy= by symlink. Both
+        must be in the list this file checks, or a unit could pass here on a
+        directive the image gate then ignores."""
+        for d in ("WantedBy", "RequiredBy"):
+            assert d in INSTALL_DIRECTIVES
+
+    def test_smoke_test_also_hard_fails_on_a_directiveless_install(self):
+        """Checked in BOTH places on purpose.
+
+        This check was briefly moved out of 05 into pytest alone — until it
+        turned out build-image.yml has no pytest step and no `needs:`, so
+        "moved to pytest" meant "removed from the release path". It is back in
+        05, narrowed, and pytest now also gates the build via a workflow step.
+        A gate that lives in exactly one place is how it went missing.
+
+        Narrow enough to be safe now: the four false-positive causes that made
+        the original version reject legal units are all fixed — the full
+        directive set, whitespace stripping, continuation joining, and comment
+        deletion.
+        """
+        body = _strip_comments(open(SMOKE_TEST_SH).read())
+        assert "no recognised install directive" in body, (
+            "05-smoke-test no longer hard-fails on an [Install] section with no directive"
+        )
+        # The shell allow-list must be the same full set this file uses, or the
+        # two disagree and a legal unit fails a 40-minute build.
+        for d in INSTALL_DIRECTIVES:
+            assert d in body, f"05-smoke-test's directive allow-list is missing {d}"
+
+    def test_smoke_test_normalises_leading_whitespace_and_continuations(self):
+        """systemd strstrip()s lines and honours `\\` continuations. Column-0
+        anchors skipped an indented [Install] entirely (litclock-dev#547's shape via
+        whitespace) and turned a continuation into a literal `\\` target."""
+        body = _strip_comments(open(SMOKE_TEST_SH).read())
+        assert "s/^[[:space:]]*//" in body, "05 must strip leading whitespace before matching [Install]"
+        assert "/\\\\$/N" in body, "05 must join line continuations before splitting targets"
+
+
+def _exclusion_list(path, var_name):
+    """Parse a bash array of bare unit names, e.g. BUILD_ENABLE_EXCLUSIONS=(...)."""
+    with open(path) as f:
+        body = f.read()
+    m = re.search(rf"^{var_name}=\((.*?)^\)", body, re.MULTILINE | re.DOTALL)
+    assert m, f"{var_name} array not found in {path}"
+    return sorted(line.strip() for line in m.group(1).splitlines() if line.strip() and not line.strip().startswith("#"))
+
+
 class TestSystemdUnitsInStage:
-    def test_stage_copies_all_required_units(self):
-        """The install-services chroot script must copy every unit the
-        clock needs at runtime."""
-        chroot_sh = os.path.join(STAGE_DIR, "03-install-services", "00-run.sh")
-        with open(chroot_sh) as f:
-            content = f.read()
+    def test_stage_globs_units_instead_of_enumerating(self):
+        """The cp list must stay derived. Re-introducing per-unit cp lines
+        reopens the litclock-dev#547 / v0.211.0 bug class.
 
-        required_units = [
-            "litclock-splash.service",
-            "litclock-firstboot.service",
-            "litclock.service",
-            "litclock.timer",
-            "litclock-shutdown.service",
-            "wifi-watchdog.service",
-            "wifi-watchdog.timer",
-            # EPIC #383 PR2 (#388) — handoff fallback completer.
-            "litclock-handoff-fallback.service",
-            "litclock-handoff-fallback.timer",
+        Comments are stripped first: a commented-out glob must not satisfy the
+        positive assertion, and a commented-out cp must not trip the negative.
+        """
+        body = _strip_comments(open(INSTALL_SERVICES_SH).read())
+        # Whitespace/brace tolerant — a cosmetic reformat should not fail the
+        # suite when behaviour is identical.
+        assert re.search(
+            r"units=\(\s*\"?\$\{?INSTALL_DIR\}?\"?/systemd/\*\.service\s+\"?\$\{?INSTALL_DIR\}?\"?/systemd/\*\.timer\s*\)",
+            body,
+        ), "03-install-services must glob systemd/ rather than naming units"
+        # Deliberately broad — any per-unit copy spelling counts, quoted or not,
+        # braced or not, indented or sudo-prefixed.
+        hardcoded = re.findall(
+            r"^\s*(?:sudo\s+)?(?:cp|install)\b[^\n]*?/systemd/[\w.\-]+\.(?:service|timer)",
+            body,
+            re.MULTILINE,
+        )
+        assert not hardcoded, f"per-unit cp/install lines reintroduced: {hardcoded}"
+
+    def test_systemd_dir_holds_only_known_unit_types(self):
+        """The three globs all assume .service/.timer. A .path, .socket or
+        .target unit would be invisible to the copy loop, the enable guard, and
+        the smoke test simultaneously — litclock-dev#547's shape, relocated from a name
+        list to an extension list. Force an explicit decision instead."""
+        unknown = [
+            f
+            for f in os.listdir(SYSTEMD_DIR)
+            if os.path.isfile(os.path.join(SYSTEMD_DIR, f)) and not f.endswith(UNIT_SUFFIXES)
         ]
-        for unit in required_units:
-            assert unit in content, f"{unit} not copied in install-services stage"
+        assert not unknown, (
+            f"unit types outside {UNIT_SUFFIXES} found in systemd/: {unknown}. "
+            f"Widen the globs in 03-install-services, 05-smoke-test and UNIT_SUFFIXES together, "
+            f"or these units will silently never reach an image."
+        )
 
-    def test_stage_enables_required_units(self):
-        chroot_sh = os.path.join(STAGE_DIR, "03-install-services", "00-run.sh")
-        with open(chroot_sh) as f:
-            content = f.read()
+    def test_systemd_subdirectories_are_all_installed(self):
+        """The meta-guard behind the one above.
 
-        required_enables = [
-            "litclock-splash.service",
-            "litclock-firstboot.service",
-            # litclock.timer is deliberately NOT enabled at build time —
-            # first-boot.sh enables it after setup completes (avoids GPIO race)
-            "litclock-shutdown.service",
-            "wifi-watchdog.timer",
-            # EPIC #383 PR2 (#388) — fallback timer (service has no [Install]).
-            "litclock-handoff-fallback.timer",
+        Every glob in 03 and 05 reads the FIRST level of systemd/ only, so a
+        subdirectory is invisible to all of them simultaneously. That is not
+        hypothetical: tmpfiles.d/ sat there for months installed by a single
+        hardcoded `cp`, checked by nothing, while the PR that exists to close
+        litclock-dev#547 added guards all around it. A new subdirectory must force an
+        explicit decision — install path, derived smoke check, tests — rather
+        than inheriting that silence.
+        """
+        subdirs = {f for f in os.listdir(SYSTEMD_DIR) if os.path.isdir(os.path.join(SYSTEMD_DIR, f))}
+        unknown = subdirs - KNOWN_SYSTEMD_SUBDIRS
+        assert not unknown, (
+            f"unhandled subdirectories in systemd/: {sorted(unknown)}. The unit globs read the "
+            f"first level only, so nothing in here reaches an image unless 03-install-services "
+            f"copies it, 05-smoke-test verifies it, and KNOWN_SYSTEMD_SUBDIRS names it."
+        )
+
+    def test_repo_names_cannot_shadow_distro_files(self):
+        """The enumerated lists made a name collision impossible; a glob does not.
+
+        /etc/tmpfiles.d shadows /usr/lib/tmpfiles.d BY BASENAME, and
+        /etc/systemd/system shadows the vendor unit directory the same way. So a
+        repo file named tmp.conf, var.conf or home.conf would silently override a
+        distro rule that owns /tmp, /var/log or /home — and these globs now copy
+        it to every fielded Pi over OTA. Suffix checks cannot see this; only a
+        name check can.
+        """
+        allowed = ("litclock", "wifi-watchdog")
+        offenders = [name for name in _repo_units() + _repo_tmpfiles() if not name.startswith(allowed)]
+        assert not offenders, (
+            f"files in systemd/ whose names are not clearly ours: {offenders}. "
+            f"/etc/tmpfiles.d and /etc/systemd/system shadow the distro's copies by basename, "
+            f"so a generic name silently overrides a vendor rule on every device."
+        )
+
+    def test_tmpfiles_dir_holds_only_conf_files(self):
+        """systemd-tmpfiles only reads *.conf from /etc/tmpfiles.d/, and both
+        stage scripts glob *.conf. A file with any other suffix would be copied
+        by nothing and read by nothing."""
+        unknown = [
+            f
+            for f in os.listdir(TMPFILES_DIR)
+            if os.path.isfile(os.path.join(TMPFILES_DIR, f)) and not f.endswith(".conf")
         ]
-        for unit in required_enables:
-            assert f"systemctl enable {unit}" in content, f"systemctl enable {unit} not found in stage"
+        assert not unknown, (
+            f"non-.conf files in systemd/tmpfiles.d/: {unknown}. systemd-tmpfiles ignores "
+            f"anything but *.conf, and so do the globs in 03-install-services and 05-smoke-test."
+        )
 
-    def test_all_copied_units_exist_in_repo(self):
-        """Every unit file the stage copies must exist in the systemd/ dir."""
-        systemd_dir = os.path.join(REPO_ROOT, "systemd")
-        chroot_sh = os.path.join(STAGE_DIR, "03-install-services", "00-run.sh")
-        with open(chroot_sh) as f:
-            content = f.read()
+    def test_stage_globs_tmpfiles_instead_of_naming_the_file(self):
+        """litclock-dev#547's shape, one directory down. `cp .../tmpfiles.d/litclock.conf`
+        is exactly the hand-maintained spelling that drifted three times for
+        units, and it is worse here: a missing drop-in produces no error at all,
+        just a clock with no /run/litclock and permanently stale status."""
+        body = _strip_comments(open(INSTALL_SERVICES_SH).read())
+        assert re.search(
+            r"tmpfiles_confs=\(\s*\"?\$\{?INSTALL_DIR\}?\"?/systemd/tmpfiles\.d/\*\.conf\s*\)",
+            body,
+        ), "03-install-services must glob systemd/tmpfiles.d/ rather than naming the drop-in"
+        hardcoded = re.findall(
+            r"^\s*(?:sudo\s+)?(?:cp|install)\b[^\n]*?/systemd/tmpfiles\.d/[\w.\-]+\.conf",
+            body,
+            re.MULTILINE,
+        )
+        assert not hardcoded, f"per-file cp/install lines reintroduced: {hardcoded}"
 
-        # Extract unit filenames from cp commands
-        for match in re.finditer(r"cp.*?/systemd/([\w.\-]+)", content):
-            unit = match.group(1)
-            assert os.path.exists(os.path.join(systemd_dir, unit)), (
-                f"Stage copies {unit} but it doesn't exist in systemd/"
+    def test_smoke_test_derives_tmpfiles_from_source_tree(self):
+        """The drop-in must be verified in the repo->image direction like the
+        units, AND asserted by absolute path as an independent backstop. The
+        derived check catches drift; the absolute path catches a corrupted
+        source tree that both derived checks would agree with."""
+        body = _strip_comments(open(SMOKE_TEST_SH).read())
+        assert 'src_tmpfiles=( "$SRC_TMPFILES_DIR"/*.conf )' in body, (
+            "smoke test must derive its tmpfiles set from the source tree"
+        )
+        # The derivation itself sits outside the sentinels (the harness below
+        # injects its own value), so assert it here or it is covered nowhere.
+        assert 'SRC_TMPFILES_DIR="${SRC_SYSTEMD_DIR}/tmpfiles.d"' in body, (
+            "SRC_TMPFILES_DIR must be derived from SRC_SYSTEMD_DIR, not named independently"
+        )
+        assert "/etc/tmpfiles.d/litclock.conf" in body, (
+            "the tmpfiles drop-in lost its absolute-path backstop in required_files"
+        )
+
+    def test_unit_syntax_check_verifies_the_staged_file_not_a_unit_name(self):
+        """`systemd-analyze verify litclock.service` resolves the name through
+        the unit load path, so it verifies whatever the CHROOT already has
+        installed — which, for a stale unit from a reused CLEAN=0 work dir, is
+        not the file this build staged. `-- "$src"` pins it to the path. The
+        `--` also keeps a unit whose name begins with a dash from being read as
+        an option. Reverting to the bare-name form leaves the build green while
+        syntax-checking the wrong file, so it is asserted here — the loop
+        itself needs a working systemd to run, which the harness has not got.
+        """
+        body = _strip_comments(open(SMOKE_TEST_SH).read())
+        assert 'systemd-analyze verify -- "$src"' in body, (
+            "the unit syntax check must verify the staged PATH, not a bare unit name"
+        )
+        # Command position only — an `echo "systemd-analyze verify exited ..."`
+        # diagnostic is not an invocation.
+        bare = [
+            ln.strip()
+            for ln in body.splitlines()
+            if re.search(r"(?:^|[|(`]|\$\()\s*systemd-analyze verify (?!-- )", ln)
+        ]
+        assert not bare, f"bare-name systemd-analyze verify reintroduced: {bare}"
+
+    def test_stage_scripts_have_no_env_overridable_destination_seams(self):
+        """Regression guard for the seam removed in 2f2d14be.
+
+        on_chroot uses capsh, which does not scrub the environment. A
+        `${ETC_SYSTEMD_DIR:-/etc/systemd/system}` seam lets a stray exported
+        variable redirect where a ROOT-run build script installs AND where it
+        verifies the result — point it at the source tree and every `cmp -s`
+        self-compares, so all three checks pass green on an uninspected image.
+        The tests inject their own assignments ahead of the sentinel blocks, so
+        no seam is needed for testability.
+        """
+        for path in (INSTALL_SERVICES_SH, SMOKE_TEST_SH):
+            body = _strip_comments(open(path).read())
+            seams = re.findall(r"\$\{(?:SRC|ETC)_(?:SYSTEMD|TMPFILES)_DIR:[-=?+]", body)
+            assert not seams, (
+                f"{os.path.basename(os.path.dirname(path))} reintroduced an env-overridable "
+                f"destination seam: {seams}. Assign unconditionally."
             )
+
+    def test_destination_paths_are_pinned_to_their_real_values(self):
+        """Forbidding the `:-` seam is not enough — it never pinned the VALUE.
+
+        These assignments sit outside every sentinel and the harness injects its
+        own paths, so their real values were exercised by nothing. A single typo
+        (`ETC_TMPFILES_DIR=/etc/tmpfile.d`) survived the whole suite green, and
+        because the copy loop runs `install -d` it CREATES the wrong directory —
+        so stage 03 exits 0 printing "OK: copied 1 tmpfiles.d drop-in(s)" on an
+        image whose tmpfiles rules are never read.
+        """
+        expected = {
+            INSTALL_SERVICES_SH: {
+                "ETC_SYSTEMD_DIR": "/etc/systemd/system",
+                "ETC_TMPFILES_DIR": "/etc/tmpfiles.d",
+            },
+            SMOKE_TEST_SH: {
+                "SRC_SYSTEMD_DIR": "/home/pi/litclock/systemd",
+                "ETC_SYSTEMD_DIR": "/etc/systemd/system",
+                "ETC_TMPFILES_DIR": "/etc/tmpfiles.d",
+            },
+        }
+        for path, wanted in expected.items():
+            body = open(path).read()
+            where = os.path.basename(os.path.dirname(path))
+            for var, value in wanted.items():
+                found = re.findall(rf"^{var}=(\S+)$", body, re.MULTILINE)
+                assert found == [value], f"{where}: {var} is {found}, expected exactly ['{value}']"
+
+    def test_every_installer_copies_what_it_enables(self):
+        """The invariant, applied to BOTH installers rather than pi-gen only.
+
+        This PR globbed pi-gen and update.sh and added 30 tests enforcing the
+        rule for pi-gen — while scripts/install.sh sat two directories away
+        running `systemctl enable litclock-reresolve-location.service` for a unit
+        its enumerated cp list never copied, under `set -e`, so the enable failed
+        and aborted the whole DIY install. Enforcing a rule on one of three
+        implementations is how it came back.
+        """
+        installers = {
+            "pi-gen/stage3/03-install-services": INSTALL_SERVICES_SH,
+            "scripts/update.sh": os.path.join(REPO_ROOT, "scripts", "update.sh"),
+        }
+        # Assert the floor rather than silently skipping: review demonstrated
+        # that renaming BOTH paths away left this test green with zero
+        # assertions executed. Same anti-vacuity pattern as _repo_units().
+        assert len(installers) == 2, f"expected 2 installers, got {sorted(installers)}"
+        for label, path in installers.items():
+            assert os.path.isfile(path), f"{label} is missing — this test would otherwise pass vacuously"
+            body = _strip_comments(open(path).read())
+            enabled = set(re.findall(r"systemctl enable ([\w.\-]+)", body))
+
+            # Which suffixes does this installer's glob actually cover? The
+            # earlier version asked a yes/no question — `re.search(r"/systemd/
+            # \*\.service")` — and `continue`d on a hit, which every installer
+            # scored, so the assertion below was dead code on all three paths.
+            # Verified: dropping the `*.timer` term from install.sh's glob left
+            # the whole suite green while install.sh enabled six timers it never
+            # copied, under `set -e`. A test written to close that exact bug,
+            # blind to it. Collect the covered suffixes instead of a boolean.
+            globbed = set(re.findall(r"/systemd/\*\.(\w+)", body))
+            copied = set(re.findall(r"/systemd/([\w.\-]+\.(?:service|timer))", body))
+
+            missing = sorted(u for u in enabled if u not in copied and u.rsplit(".", 1)[-1] not in globbed)
+            assert not missing, (
+                f"{label} enables units it neither copies explicitly nor covers with a glob: "
+                f"{missing} (globbed suffixes: {sorted(globbed) or 'none'}). "
+                f"Under `set -e` the enable aborts the whole install (the #14 bug); "
+                f"without it the unit ships disabled forever (litclock-dev#547)."
+            )
+
+    def test_tmpfiles_floors_agree_and_are_real_floors(self):
+        stage_floor = _shell_floor(INSTALL_SERVICES_SH, "MIN_EXPECTED_TMPFILES")
+        smoke_floor = _shell_floor(SMOKE_TEST_SH, "MIN_EXPECTED_TMPFILES")
+        assert stage_floor == smoke_floor, (
+            f"tmpfiles floors drifted: 03-install-services={stage_floor}, 05-smoke-test={smoke_floor}"
+        )
+        # There is only one drop-in today, so unlike the unit floor this one is
+        # allowed to EQUAL the real count. It must still be >= 1, or the glob
+        # matching nothing — the case it exists for — would pass.
+        assert stage_floor >= 1, "a floor of 0 cannot catch a glob that matched nothing"
+        assert stage_floor <= len(_repo_tmpfiles()), (
+            f"floor {stage_floor} exceeds the real drop-in count {len(_repo_tmpfiles())}"
+        )
+
+    def test_floors_agree_and_sit_below_the_real_count(self):
+        """Both stage scripts carry MIN_EXPECTED_UNITS. They must match, and the
+        floor must actually be a floor — a floor at or above the real count
+        would fail every build."""
+        stage_floor = _shell_floor(INSTALL_SERVICES_SH)
+        smoke_floor = _shell_floor(SMOKE_TEST_SH)
+        assert stage_floor == smoke_floor, (
+            f"floors drifted: 03-install-services={stage_floor}, 05-smoke-test={smoke_floor}"
+        )
+        assert stage_floor < len(_repo_units()), (
+            f"floor {stage_floor} is not below the real unit count {len(_repo_units())}"
+        )
+
+    def test_every_install_unit_is_enabled_or_explicitly_excluded(self):
+        """A unit shipping an [Install] section must either be enabled at build
+        time or named in BUILD_ENABLE_EXCLUSIONS. This is the guard that would
+        have caught litclock-reresolve-location.service (litclock-dev#547): it has
+        [Install] WantedBy=multi-user.target and was in neither place."""
+        body = _strip_comments(open(INSTALL_SERVICES_SH).read())
+        enabled = set(re.findall(r"^systemctl enable ([\w.\-]+)", body, re.MULTILINE))
+        excluded = set(_exclusion_list(INSTALL_SERVICES_SH, "BUILD_ENABLE_EXCLUSIONS"))
+
+        missing = [u for u in _units_with_install_section() if u not in enabled and u not in excluded]
+        assert not missing, (
+            f"units carry [Install] but are neither enabled at build time nor listed in "
+            f"BUILD_ENABLE_EXCLUSIONS: {missing}. Either enable them, or add them to the "
+            f"exclusion list with a comment explaining why they must not be enabled."
+        )
+
+    def test_reresolve_location_is_enabled(self):
+        """litclock-dev#547 regression. Copy alone does not fix it: update.sh's
+        `was_pre_existing` check treats an already-present unit file as
+        pre-existing and never auto-enables it,
+        so an image that copies without enabling strands the unit disabled
+        forever on every Pi flashed from it."""
+        body = _strip_comments(open(INSTALL_SERVICES_SH).read())
+        assert "systemctl enable litclock-reresolve-location.service" in body
+
+    def test_enabled_units_all_exist_in_repo(self):
+        """Inverse direction: nothing is enabled that we do not ship."""
+        body = _strip_comments(open(INSTALL_SERVICES_SH).read())
+        for unit in re.findall(r"^systemctl enable ([\w.\-]+)", body, re.MULTILINE):
+            assert unit in _repo_units(), f"stage enables {unit} but it is not in systemd/"
+
+    def test_exclusion_lists_agree_across_stage_and_smoke_test(self):
+        """03 and 05 each carry an exclusion list. They must stay identical or
+        the smoke test would silently stop verifying a real exclusion."""
+        assert _exclusion_list(INSTALL_SERVICES_SH, "BUILD_ENABLE_EXCLUSIONS") == _exclusion_list(
+            SMOKE_TEST_SH, "SMOKE_ENABLE_EXCLUSIONS"
+        )
+
+    def test_exclusions_name_real_install_units(self):
+        """Checking the two lists against each other proves only that they
+        agree, not that they mean anything. A typo (litclock.timers) or a name
+        left behind after a unit is deleted would agree with itself forever
+        while protecting nothing, and the shell-side sanity loop cannot catch
+        it either — it probes for a path that will never exist, so it always
+        passes."""
+        excluded = set(_exclusion_list(INSTALL_SERVICES_SH, "BUILD_ENABLE_EXCLUSIONS"))
+        install_units = set(_units_with_install_section())
+        bogus = excluded - install_units
+        assert not bogus, (
+            f"BUILD_ENABLE_EXCLUSIONS names units that do not exist or carry no [Install] "
+            f"section: {sorted(bogus)}. A stale exclusion silently protects nothing."
+        )
+
+    def test_smoke_test_derives_units_from_source_tree(self):
+        """05-smoke-test previously named 7 of 20 units by hand, so it passed
+        green on the litclock-dev#547 bug it existed to catch."""
+        body = _strip_comments(open(SMOKE_TEST_SH).read())
+        assert 'src_units=( "$SRC_SYSTEMD_DIR"/*.service' in body, (
+            "smoke test must derive its unit set from the source tree"
+        )
+        # Three absolute paths are deliberate: they are an INDEPENDENT backstop
+        # that does not read the source tree, so source corruption fails them
+        # even when the derived check agrees with a wrong tree. Anything beyond
+        # these three is drift.
+        intentional = {
+            "/etc/systemd/system/litclock.service",
+            "/etc/systemd/system/litclock.timer",
+            "/etc/systemd/system/wifi-watchdog.service",
+        }
+        found_paths = {p.strip() for p in re.findall(r"^\s+(/etc/systemd/system/[\w.\-]+)$", body, re.MULTILINE)}
+        assert intentional <= found_paths, (
+            f"the independent load-bearing backstop was removed: {sorted(intentional - found_paths)}. "
+            f"Without it, a corrupted source tree passes both gates (they read the same tree)."
+        )
+        stale = found_paths - intentional
+        assert not stale, f"hardcoded unit paths beyond the intentional backstop: {sorted(stale)}"
+
+
+# ── The copy guard must FAIL, not merely print ───────────────────────
+
+
+def _extract_block(path, name):
+    """Pull a sentinel-bracketed block out of a stage script, so these tests
+    exercise the shipped assertions rather than a reimplementation of them.
+    If someone edits the block, these tests run the edited version.
+
+    Anchored on explicit sentinels, not on a human-readable log line. With a
+    log-line anchor the covered region could silently SHRINK (a guard added
+    after the echo would go unexercised with no test failure), and a cosmetic
+    reword of the echo would hard-fail the suite for a non-behavioural edit.
+    """
+    body = open(path).read()
+    m = re.search(rf"^# BEGIN {name}\b.*?$(.*?)^# END {name}\b", body, re.MULTILINE | re.DOTALL)
+    assert m, f"{name} sentinels not found in {os.path.basename(os.path.dirname(path))}/00-run.sh"
+    return m.group(1)
+
+
+def _extract_copy_guard():
+    guard = _extract_block(INSTALL_SERVICES_SH, "copy-guard")
+    assert "MIN_EXPECTED_UNITS" in guard, "copy-guard region no longer contains the floor check"
+    assert 'copied" -ne "$found' in guard, "copy-guard region no longer contains the equality check"
+    return guard
+
+
+def _extract_tmpfiles_guard():
+    guard = _extract_block(INSTALL_SERVICES_SH, "tmpfiles-guard")
+    assert "MIN_EXPECTED_TMPFILES" in guard, "tmpfiles-guard region no longer contains the floor check"
+    assert 'tmpfiles_copied" -ne "$tmpfiles_found' in guard, (
+        "tmpfiles-guard region no longer contains the equality check"
+    )
+    return guard
+
+
+def _run_tmpfiles_guard(found, copied):
+    script = f"set -e\ntmpfiles_found={found}\ntmpfiles_copied={copied}\n{_extract_tmpfiles_guard()}\n"
+    return subprocess.run(["bash", "-c", script], capture_output=True, text=True, timeout=15)
+
+
+def _run_copy_guard(found, copied):
+    script = f"set -e\nfound={found}\ncopied={copied}\n{_extract_copy_guard()}\n"
+    return subprocess.run(["bash", "-c", script], capture_output=True, text=True, timeout=15)
+
+
+class TestCopyGuardFailsLoudly:
+    """A gate that prints a mismatch and exits 0 is not a gate.
+
+    Each case feeds the SHIPPED guard a tampered input and asserts a non-zero
+    exit. Without these, the guard could be silently broken by a refactor and
+    every build would keep passing — which is exactly how the hardcoded lists
+    this PR replaces managed to drift unnoticed for three releases.
+    """
+
+    def test_healthy_case_passes(self):
+        real = len(_repo_units())
+        assert _run_copy_guard(real, real).returncode == 0
+
+    def test_zero_units_fails(self):
+        """The catastrophic case: glob matched nothing, image would be inert."""
+        result = _run_copy_guard(0, 0)
+        assert result.returncode != 0
+        assert "floor" in result.stderr.lower()
+
+    def test_partial_source_tree_fails(self):
+        """Half-failed 01-setup-app: found == copied, but both are small.
+        The equality check alone cannot catch this; the floor is what does."""
+        assert _run_copy_guard(3, 3).returncode != 0
+
+    def test_copy_count_mismatch_fails(self):
+        assert _run_copy_guard(20, 19).returncode != 0
+
+
+class TestTmpfilesGuardFailsLoudly:
+    """Same treatment for the tmpfiles copy. The floor matters MORE here than
+    for units: a missing unit eventually surfaces as a service that will not
+    start, while a missing /run/litclock surfaces as nothing whatsoever."""
+
+    def test_healthy_case_passes(self):
+        real = len(_repo_tmpfiles())
+        assert _run_tmpfiles_guard(real, real).returncode == 0
+
+    def test_zero_dropins_fails(self):
+        """The glob matched nothing — `cp` would have failed under errexit,
+        a glob exits 0 and ships an image with no /run/litclock."""
+        result = _run_tmpfiles_guard(0, 0)
+        assert result.returncode != 0
+        assert "floor" in result.stderr.lower()
+
+    def test_copy_count_mismatch_fails(self):
+        assert _run_tmpfiles_guard(2, 1).returncode != 0
+
+
+# ── The 03 copy + exclusion LOOPS, not just their counters ───────────
+#
+# The guards above only ever saw integers. Everything that decides what
+# actually lands in the image — the glob, the symlink rejection, the
+# `install -m 0644` mode, the every-*.wants exclusion probe — sat outside any
+# sentinel and was verified by nothing. Four of the five behavioural changes in
+# this PR survived outright deletion with the whole suite green.
+
+
+_INSTALL_STUB = r"""#!/bin/bash
+# Records argv, then delegates to the real install with -o/-g stripped: the
+# harness does not run as root, so ownership is asserted from the recorded
+# arguments while mode and content are asserted from the real files.
+printf '%s\n' "$*" >> "$INSTALL_LOG"
+args=(); skip=0
+for a in "$@"; do
+    if [ "$skip" = 1 ]; then skip=0; continue; fi
+    case "$a" in
+        -o|-g) skip=1 ;;
+        *) args+=( "$a" ) ;;
+    esac
+done
+exec /usr/bin/install "${args[@]}"
+"""
+
+
+def _run_stage_block(name, tmp_path, assigns, preamble=""):
+    """Run a sentinel block from 03-install-services under bash.
+
+    Returns (CompletedProcess, recorded `install` argv lines).
+    """
+    bindir = tmp_path / "stubbin"
+    bindir.mkdir(exist_ok=True)
+    stub = bindir / "install"
+    stub.write_text(_INSTALL_STUB)
+    stub.chmod(0o755)
+    log = tmp_path / "install.log"
+
+    script = (
+        "set -e\n"
+        + "".join(f"{k}={shlex.quote(str(v))}\n" for k, v in assigns.items())
+        + f"{preamble}\n"
+        + f"{_extract_block(INSTALL_SERVICES_SH, name)}\n"
+    )
+    env = {**os.environ, "PATH": f"{bindir}:{os.environ['PATH']}", "INSTALL_LOG": str(log)}
+    r = subprocess.run(["bash", "-c", script], capture_output=True, text=True, timeout=15, env=env)
+    return r, (log.read_text().splitlines() if log.exists() else [])
+
+
+def _fake_install_dir(tmp_path, units=None, confs=None):
+    """A miniature INSTALL_DIR plus empty destination trees."""
+    install_dir = tmp_path / "litclock"
+    (install_dir / "systemd" / "tmpfiles.d").mkdir(parents=True, exist_ok=True)
+    for name, body in (units or {}).items():
+        (install_dir / "systemd" / name).write_text(body)
+    for name, body in (confs or {}).items():
+        (install_dir / "systemd" / "tmpfiles.d" / name).write_text(body)
+    etc = tmp_path / "etc-systemd"
+    etc_tmpfiles = tmp_path / "etc-tmpfiles"
+    etc.mkdir(exist_ok=True)
+    etc_tmpfiles.mkdir(exist_ok=True)
+    return install_dir, etc, etc_tmpfiles
+
+
+class TestUnitCopyLoop:
+    """The loop that decides what reaches /etc/systemd/system/."""
+
+    def _assigns(self, install_dir, etc, etc_tmpfiles):
+        return {"INSTALL_DIR": install_dir, "ETC_SYSTEMD_DIR": etc, "ETC_TMPFILES_DIR": etc_tmpfiles}
+
+    def test_globs_every_unit_and_counts_them(self, tmp_path):
+        """A glob cannot forget a new unit — that is the whole point of the
+        change, and nothing was checking that the glob ran at all."""
+        install_dir, etc, etc_t = _fake_install_dir(
+            tmp_path, units={"a.service": PLAIN, "b.timer": PLAIN, "c.service": PLAIN}
+        )
+        r, _ = _run_stage_block("unit-copy-loop", tmp_path, self._assigns(install_dir, etc, etc_t))
+        assert r.returncode == 0, r.stderr
+        assert sorted(p.name for p in etc.iterdir()) == ["a.service", "b.timer", "c.service"]
+
+    def test_non_unit_suffixes_are_not_copied(self, tmp_path):
+        """The glob is *.service/*.timer. A README or a .conf in systemd/ must
+        not be shovelled into /etc/systemd/system/."""
+        install_dir, etc, etc_t = _fake_install_dir(
+            tmp_path, units={"a.service": PLAIN, "README.md": "x\n", "notes.conf": "y\n"}
+        )
+        r, _ = _run_stage_block("unit-copy-loop", tmp_path, self._assigns(install_dir, etc, etc_t))
+        assert r.returncode == 0, r.stderr
+        assert [p.name for p in etc.iterdir()] == ["a.service"]
+
+    def test_executable_source_lands_non_executable(self, tmp_path):
+        """`install -m 0644` rather than `cp`. cp applies the SOURCE mode, so a
+        unit committed with the exec bit set would land executable in
+        /etc/systemd/system/. Reverting to cp reds this test.
+
+        Run over a MULTI-unit fixture: with one unit, a per-file guarantee and a
+        once-anywhere guarantee are indistinguishable.
+        """
+        install_dir, etc, etc_t = _fake_install_dir(
+            tmp_path, units={"a.service": PLAIN, "b.timer": PLAIN, "c.service": PLAIN}
+        )
+        (install_dir / "systemd" / "a.service").chmod(0o755)
+        (install_dir / "systemd" / "c.service").chmod(0o600)
+        r, calls = _run_stage_block("unit-copy-loop", tmp_path, self._assigns(install_dir, etc, etc_t))
+        assert r.returncode == 0, r.stderr
+        for name in ("a.service", "b.timer", "c.service"):
+            mode = stat.S_IMODE((etc / name).stat().st_mode)
+            assert mode == 0o644, f"{name} landed with mode {oct(mode)}"
+        # Ownership cannot be asserted as an effect without root, so assert the
+        # intent from the recorded argv. `all`, not `any`: the tmpfiles loop
+        # already logs two calls, so a future `install -d -o root -g root` would
+        # satisfy an `any` after the file copy lost its ownership flags.
+        copy_calls = [c for c in calls if not c.startswith("-d")]
+        assert len(copy_calls) == 3, f"expected one install call per unit, got {copy_calls}"
+        assert all("-m 0644 -o root -g root" in c for c in copy_calls), (
+            f"not every unit was installed 0644 root:root — {copy_calls}"
+        )
+
+    def test_symlinked_unit_is_rejected(self, tmp_path):
+        """01-setup-app stages with `cp -a`, which preserves symlinks. A
+        symlinked unit would have its target's content silently copied out."""
+        install_dir, etc, etc_t = _fake_install_dir(tmp_path, units={"real.service": PLAIN})
+        (install_dir / "systemd" / "link.timer").symlink_to(install_dir / "systemd" / "real.service")
+        r, _ = _run_stage_block("unit-copy-loop", tmp_path, self._assigns(install_dir, etc, etc_t))
+        assert r.returncode != 0
+        assert "not a regular file" in r.stderr
+
+    def test_directory_named_like_a_unit_is_rejected(self, tmp_path):
+        install_dir, etc, etc_t = _fake_install_dir(tmp_path, units={"a.service": PLAIN})
+        (install_dir / "systemd" / "weird.service").mkdir()
+        r, _ = _run_stage_block("unit-copy-loop", tmp_path, self._assigns(install_dir, etc, etc_t))
+        assert r.returncode != 0
+        assert "not a regular file" in r.stderr
+
+    def test_empty_source_tree_exits_zero_with_found_zero(self, tmp_path):
+        """The loop itself cannot fail here — an unmatched glob is not an
+        error. That is precisely why the copy-guard exists downstream, and this
+        test pins the seam between the two so neither is assumed to cover it."""
+        install_dir, etc, etc_t = _fake_install_dir(tmp_path)
+        r, _ = _run_stage_block(
+            "unit-copy-loop", tmp_path, self._assigns(install_dir, etc, etc_t), preamble="trap 'echo found=$found' EXIT"
+        )
+        assert r.returncode == 0
+        assert "found=0" in r.stdout
+
+
+class TestTmpfilesCopyLoop:
+    def _assigns(self, install_dir, etc, etc_tmpfiles):
+        return {"INSTALL_DIR": install_dir, "ETC_SYSTEMD_DIR": etc, "ETC_TMPFILES_DIR": etc_tmpfiles}
+
+    def test_globs_every_dropin(self, tmp_path):
+        install_dir, etc, etc_t = _fake_install_dir(
+            tmp_path, confs={"litclock.conf": TMPFILES_BODY, "extra.conf": TMPFILES_BODY}
+        )
+        r, _ = _run_stage_block("tmpfiles-copy-loop", tmp_path, self._assigns(install_dir, etc, etc_t))
+        assert r.returncode == 0, r.stderr
+        assert sorted(p.name for p in etc_t.iterdir()) == ["extra.conf", "litclock.conf"]
+
+    def test_executable_source_lands_non_executable(self, tmp_path):
+        install_dir, etc, etc_t = _fake_install_dir(tmp_path, confs={"litclock.conf": TMPFILES_BODY})
+        (install_dir / "systemd" / "tmpfiles.d" / "litclock.conf").chmod(0o777)
+        r, calls = _run_stage_block("tmpfiles-copy-loop", tmp_path, self._assigns(install_dir, etc, etc_t))
+        assert r.returncode == 0, r.stderr
+        assert stat.S_IMODE((etc_t / "litclock.conf").stat().st_mode) == 0o644
+        copy_calls = [c for c in calls if not c.startswith("-d")]
+        assert copy_calls and all("-m 0644 -o root -g root" in c for c in copy_calls), (
+            f"drop-in was not installed 0644 root:root — {copy_calls}"
+        )
+
+    def test_symlinked_dropin_is_rejected(self, tmp_path):
+        install_dir, etc, etc_t = _fake_install_dir(tmp_path, confs={"real.conf": TMPFILES_BODY})
+        d = install_dir / "systemd" / "tmpfiles.d"
+        (d / "link.conf").symlink_to(d / "real.conf")
+        r, _ = _run_stage_block("tmpfiles-copy-loop", tmp_path, self._assigns(install_dir, etc, etc_t))
+        assert r.returncode != 0
+        assert "not a regular file" in r.stderr
+
+    def test_destination_directory_is_created(self, tmp_path):
+        """/etc/tmpfiles.d exists on Debian, but the loop must not depend on
+        that — `install -d` is what makes the copy safe on any rootfs."""
+        install_dir, etc, etc_t = _fake_install_dir(tmp_path, confs={"litclock.conf": TMPFILES_BODY})
+        etc_t.rmdir()
+        r, _ = _run_stage_block("tmpfiles-copy-loop", tmp_path, self._assigns(install_dir, etc, etc_t))
+        assert r.returncode == 0, r.stderr
+        assert (etc_t / "litclock.conf").is_file()
+        # Mode matters as much as existence: `install -d -m 0777` survived the
+        # whole suite green, which is a world-writable /etc/tmpfiles.d created by
+        # a root-run build script on a shipped image.
+        mode = stat.S_IMODE(etc_t.stat().st_mode)
+        assert mode == 0o755, f"/etc/tmpfiles.d created with mode {oct(mode)}"
+
+
+class TestEnableExclusionCheck:
+    """A guard that cannot fail is the exact failure mode 03 exists to remove.
+
+    Before this class, reverting the every-*.wants probe to the old hardcoded
+    multi-user.target pair left the suite fully green — the same defect this PR
+    fixes in the 05 counterpart, unfixed in 03 because nothing tested it.
+    """
+
+    def _run(self, tmp_path, etc, exclusions):
+        arr = " ".join(exclusions)
+        return _run_stage_block(
+            "enable-exclusion-check",
+            tmp_path,
+            {"ETC_SYSTEMD_DIR": etc},
+            preamble=f"BUILD_ENABLE_EXCLUSIONS=( {arr} )",
+        )[0]
+
+    def _enable(self, etc, target, unit):
+        d = etc / f"{target}.wants"
+        d.mkdir(exist_ok=True)
+        (d / unit).write_text("")
+
+    def test_excluded_unit_left_disabled_passes(self, tmp_path):
+        _, etc, _ = _fake_install_dir(tmp_path)
+        self._enable(etc, "multi-user.target", "something-else.service")
+        assert self._run(tmp_path, etc, ["litclock.timer"]).returncode == 0
+
+    def test_excluded_unit_enabled_in_multi_user_fails(self, tmp_path):
+        """The obvious case: an `systemctl enable litclock.timer` line added
+        above without removing it from the exclusion list."""
+        _, etc, _ = _fake_install_dir(tmp_path)
+        self._enable(etc, "multi-user.target", "litclock.timer")
+        r = self._run(tmp_path, etc, ["litclock.timer"])
+        assert r.returncode != 0
+        assert "deliberate" in r.stderr.lower() or "BUILD_ENABLE_EXCLUSIONS" in r.stderr
+
+    def test_excluded_unit_enabled_in_an_unexpected_target_fails(self, tmp_path):
+        """The reason the probe globs every *.wants. A unit enabled into
+        timers.target, sockets.target or a custom target sails past a
+        hardcoded multi-user/timers pair while genuinely being enabled — and
+        litclock.timer's own [Install] is WantedBy=timers.target, so the
+        hardcoded pair was checking the wrong directory for the one unit on
+        the list."""
+        _, etc, _ = _fake_install_dir(tmp_path)
+        self._enable(etc, "sockets.target", "litclock.timer")
+        assert self._run(tmp_path, etc, ["litclock.timer"]).returncode != 0
+
+    def test_empty_exclusion_list_passes(self, tmp_path):
+        """`set -u` is not in force here, but an empty array must not explode
+        or silently short-circuit into a pass that means nothing."""
+        _, etc, _ = _fake_install_dir(tmp_path)
+        assert self._run(tmp_path, etc, []).returncode == 0
+
+
+# ── The smoke-test loops must FAIL too ───────────────────────────────
+#
+# 05 is the last gate before an image is produced, and it runs ONLY inside a
+# ~40 minute image build — a logic error there surfaces an hour in, or worse,
+# silently stops catching things. Same treatment as the 03 guards: run the
+# SHIPPED loop, not a reimplementation.
+
+
+def _extract_smoke_block(name):
+    return _extract_block(SMOKE_TEST_SH, name)
+
+
+def _run_smoke_block(name, src_dir, etc_dir, preamble=""):
+    # Exclusions parsed from the SHIPPED array, not retyped. A hardcoded
+    # `( litclock.timer )` here would keep passing after the real list changed,
+    # so the harness would be verifying a policy the build no longer has —
+    # while _exclusion_list() already exists two hundred lines up.
+    exclusions = " ".join(_exclusion_list(SMOKE_TEST_SH, "SMOKE_ENABLE_EXCLUSIONS"))
+    script = (
+        "set -e\n"
+        f'SRC_SYSTEMD_DIR="{src_dir}"\n'
+        f'ETC_SYSTEMD_DIR="{etc_dir}"\n'
+        f"SMOKE_ENABLE_EXCLUSIONS=( {exclusions} )\n"
+        f"{preamble}\n"
+        f"{_extract_smoke_block(name)}\n"
+    )
+    return subprocess.run(["bash", "-c", script], capture_output=True, text=True, timeout=15)
+
+
+def _fake_tree(tmp_path, units, installed=None, wants=None, pad=True):
+    """Build a miniature source + installed tree. units maps name -> file body.
+
+    Padded to clear MIN_EXPECTED_UNITS by default: unit-install-check declares
+    its own floor, so a fixture below it would trip the floor instead of the
+    behaviour under test. Pass pad=False to exercise the floor itself.
+
+    The padding is load-bearing for unit-install-check ONLY. enable-symlink-check
+    declares no floor and every caller overrides src_units via preamble, so the
+    pad units are inert there — do not read this as a guarantee for all callers.
+    """
+    src = tmp_path / "systemd"
+    etc = tmp_path / "etc"
+    src.mkdir(exist_ok=True)
+    etc.mkdir(exist_ok=True)
+    if pad:
+        floor = _shell_floor(SMOKE_TEST_SH)
+        units = dict(units)
+        for i in range(floor):
+            units.setdefault(f"pad{i}.service", PLAIN)
+    for unit_name, body in units.items():
+        (src / unit_name).write_text(body)
+    to_install = units if installed is None else [*installed, *[u for u in units if u.startswith("pad")]]
+    for unit_name in to_install:
+        (etc / unit_name).write_text(units[unit_name])
+    for target, names in (wants or {}).items():
+        d = etc / f"{target}.wants"
+        d.mkdir(exist_ok=True)
+        for unit_name in names:
+            (d / unit_name).write_text("")
+    return str(src), str(etc)
+
+
+PLAIN = "[Unit]\nDescription=x\n[Service]\nExecStart=/bin/true\n"
+INSTALLED_UNIT = PLAIN + "[Install]\nWantedBy=multi-user.target\n"
+
+
+class TestSmokeTestLoopsFailLoudly:
+    """The 05 loops carry the same burden as the 03 guard: they must exit
+    non-zero on a broken image, not merely print."""
+
+    def test_all_installed_and_matching_passes(self, tmp_path):
+        src, etc = _fake_tree(tmp_path, {"a.service": PLAIN, "b.timer": PLAIN})
+        assert _run_smoke_block("unit-install-check", src, etc).returncode == 0
+
+    def test_unit_never_installed_fails(self, tmp_path):
+        """The litclock-dev#547 shape: present in systemd/, absent from the image.
+
+        Asserted on the DISTINGUISHING text. Both this check and the `cmp -s`
+        immediately after it name the offending unit, so `"b.timer" in stdout`
+        passed just as happily when the never-installed branch was deleted and
+        cmp caught it instead — which is a different failure with a different
+        cause, and the one case where cmp cannot substitute is a missing
+        destination file, exactly this one."""
+        src, etc = _fake_tree(tmp_path, {"a.service": PLAIN, "b.timer": PLAIN}, installed=["a.service"])
+        r = _run_smoke_block("unit-install-check", src, etc)
+        assert r.returncode != 0
+        assert "b.timer" in r.stdout
+        assert "never installed" in r.stdout, f"masked by the cmp -s branch: {r.stdout!r}"
+
+    def test_installed_unit_differing_from_source_fails(self, tmp_path):
+        """Stale unit from a reused CLEAN=0 work dir satisfies -e but differs."""
+        src, etc = _fake_tree(tmp_path, {"a.service": PLAIN, "b.timer": PLAIN})
+        (tmp_path / "etc" / "a.service").write_text(PLAIN + "# drifted\n")
+        assert _run_smoke_block("unit-install-check", src, etc).returncode != 0
+
+    def test_empty_source_tree_fails(self, tmp_path):
+        src, etc = _fake_tree(tmp_path, {}, pad=False)
+        assert _run_smoke_block("unit-install-check", src, etc).returncode != 0
+
+    def test_install_unit_missing_its_symlink_fails(self, tmp_path):
+        """The .wants directory EXISTS and holds other units — the only state a
+        real image is ever in. multi-user.target.wants/ always exists on a Pi,
+        so a fixture with no directory at all let the guard be reduced to a
+        container-existence check and stay green while being 100% inert in the
+        field."""
+        src, etc = _fake_tree(
+            tmp_path, {"a.service": INSTALLED_UNIT}, wants={"multi-user.target": ["someone-else.service"]}
+        )
+        r = _run_smoke_block("enable-symlink-check", src, etc, preamble='src_units=( "$SRC_SYSTEMD_DIR"/a.service )')
+        assert r.returncode != 0
+        assert "no enable symlink" in r.stdout
+
+    def test_install_unit_missing_its_symlink_and_its_wants_dir_fails(self, tmp_path):
+        """The other half: no .wants directory at all. Rarer in the field, but
+        it is what a half-run `systemctl enable` leaves behind."""
+        src, etc = _fake_tree(tmp_path, {"a.service": INSTALLED_UNIT}, wants={})
+        r = _run_smoke_block("enable-symlink-check", src, etc, preamble='src_units=( "$SRC_SYSTEMD_DIR"/a.service )')
+        assert r.returncode != 0
+        assert "no enable symlink" in r.stdout
+
+    def test_install_unit_with_symlink_passes(self, tmp_path):
+        src, etc = _fake_tree(tmp_path, {"a.service": INSTALLED_UNIT}, wants={"multi-user.target": ["a.service"]})
+        assert (
+            _run_smoke_block(
+                "enable-symlink-check", src, etc, preamble='src_units=( "$SRC_SYSTEMD_DIR"/a.service )'
+            ).returncode
+            == 0
+        )
+
+    def test_excluded_unit_that_got_enabled_fails(self, tmp_path):
+        """litclock.timer enabled at build time would start the clock before
+        provisioning finishes and race splash/firstboot for GPIO."""
+        src, etc = _fake_tree(
+            tmp_path,
+            {"litclock.timer": PLAIN + "[Install]\nWantedBy=timers.target\n"},
+            wants={"timers.target": ["litclock.timer"]},
+        )
+        r = _run_smoke_block(
+            "enable-symlink-check", src, etc, preamble='src_units=( "$SRC_SYSTEMD_DIR"/litclock.timer )'
+        )
+        assert r.returncode != 0
+        assert "deliberate build-time exclusion" in r.stdout
+
+    @pytest.mark.parametrize(
+        "directive",
+        ["Alias=other.service", "Also=other.service", "UpheldBy=other.target", "DefaultInstance=main"],
+    )
+    def test_unverifiable_directives_report_but_do_not_fail(self, tmp_path, directive):
+        """Alias=, Also= and UpheldBy= are legal [Install] directives whose
+        enablement the .wants/.requires convention cannot verify. Hard-failing
+        on them blocked every build the moment someone shipped such a unit —
+        UpheldBy= has been valid since systemd 249 and passes
+        `systemd-analyze verify` clean."""
+        src, etc = _fake_tree(tmp_path, {"a.service": PLAIN + f"[Install]\n{directive}\n"})
+        r = _run_smoke_block("enable-symlink-check", src, etc, preamble='src_units=( "$SRC_SYSTEMD_DIR"/a.service )')
+        assert r.returncode == 0, r.stdout
+        assert "not verified here" in r.stdout
+
+    def test_requiredby_is_verified_via_the_requires_dir(self, tmp_path):
+        """RequiredBy= creates <target>.requires/<unit>, exactly as checkable as
+        .wants/. It used to be lumped in with Alias=/Also= as unverifiable,
+        which would have let a future RequiredBy= unit ship un-enabled behind a
+        NOTE — litclock-dev#547 surviving inside the check built to eliminate it."""
+        unit = PLAIN + "[Install]\nRequiredBy=multi-user.target\n"
+        src, etc = _fake_tree(tmp_path, {"a.service": unit}, wants={"multi-user.target": ["someone-else.service"]})
+        r = _run_smoke_block("enable-symlink-check", src, etc, preamble='src_units=( "$SRC_SYSTEMD_DIR"/a.service )')
+        assert r.returncode != 0
+        assert ".requires symlink" in r.stdout
+
+        req = tmp_path / "etc" / "multi-user.target.requires"
+        req.mkdir()
+        (req / "a.service").write_text("")
+        ok = _run_smoke_block("enable-symlink-check", src, etc, preamble='src_units=( "$SRC_SYSTEMD_DIR"/a.service )')
+        assert ok.returncode == 0, ok.stdout
+
+    def test_install_with_no_directive_at_all_hard_fails(self, tmp_path):
+        """The literal litclock-dev#547 typo. `systemd-analyze verify` exits 0 on it
+        (verified on systemd 255: `Unknown key name 'WnatedBy' ... ignoring.`,
+        rc=0), so the syntax loop cannot catch it either — this is the only
+        build-time gate that sees it."""
+        src, etc = _fake_tree(tmp_path, {"a.service": PLAIN + "[Install]\nWnatedBy=multi-user.target\n"})
+        r = _run_smoke_block("enable-symlink-check", src, etc, preamble='src_units=( "$SRC_SYSTEMD_DIR"/a.service )')
+        assert r.returncode != 0, r.stdout
+        assert "no recognised install directive" in r.stdout
+
+    def test_backslash_comment_above_install_does_not_hide_the_unit(self, tmp_path):
+        """systemd does NOT continue a comment line — a unit whose comment above
+        [Install] ends in a backslash is enabled normally (verified against a
+        real `systemctl --root=` tree). Joining that continuation turned the
+        section header into `# comment [Install]`, so the unit was skipped by
+        this entire check with no output: the silent-skip the normalisation was
+        added to close, reintroduced by the normalisation."""
+        unit = "[Unit]\nDescription=x\n# a trailing comment continuation \\\n[Install]\nWantedBy=multi-user.target\n"
+        src, etc = _fake_tree(tmp_path, {"a.service": unit}, wants={"multi-user.target": ["someone-else.service"]})
+        r = _run_smoke_block("enable-symlink-check", src, etc, preamble='src_units=( "$SRC_SYSTEMD_DIR"/a.service )')
+        assert r.returncode != 0, f"unit was skipped instead of verified: {r.stdout!r}"
+        assert "no enable symlink" in r.stdout
+
+    def test_backslash_comment_inside_install_does_not_eat_wantedby(self, tmp_path):
+        """Same bug one level in: `# note \\` inside [Install] swallowed the
+        following WantedBy= and downgraded a verifiable unit to a NOTE."""
+        unit = PLAIN + "[Install]\n# note \\\nWantedBy=multi-user.target\n"
+        src, etc = _fake_tree(tmp_path, {"a.service": unit}, wants={"multi-user.target": ["a.service"]})
+        r = _run_smoke_block("enable-symlink-check", src, etc, preamble='src_units=( "$SRC_SYSTEMD_DIR"/a.service )')
+        assert r.returncode == 0, r.stdout
+        assert "not verified here" not in r.stdout, "WantedBy= was swallowed by the comment continuation"
+
+    def test_indented_install_section_is_still_verified(self, tmp_path):
+        """systemd strstrip()s every line, so this unit is legal. A column-0
+        `grep -q '^\\[Install\\]'` skipped it entirely and the loop verified
+        nothing — litclock-dev#547's own failure mode via whitespace."""
+        unit = "[Unit]\nDescription=x\n  [Install]\n  WantedBy=multi-user.target\n"
+        src, etc = _fake_tree(tmp_path, {"a.service": unit}, wants={"multi-user.target": ["someone-else.service"]})
+        r = _run_smoke_block("enable-symlink-check", src, etc, preamble='src_units=( "$SRC_SYSTEMD_DIR"/a.service )')
+        assert r.returncode != 0, "indented [Install] was skipped instead of verified"
+        assert "no enable symlink" in r.stdout
+
+    def test_line_continuation_targets_are_all_verified(self, tmp_path):
+        """`WantedBy=a.target \\` + `b.target` is legal and enables into BOTH.
+        Unjoined it produced a literal `\\` target (hard-failing a healthy
+        build) and dropped the continued target entirely."""
+        unit = PLAIN + "[Install]\nWantedBy=multi-user.target \\\n         extra.target\n"
+        src, etc = _fake_tree(
+            tmp_path,
+            {"a.service": unit},
+            wants={"multi-user.target": ["a.service"], "extra.target": ["someone-else.service"]},
+        )
+        r = _run_smoke_block("enable-symlink-check", src, etc, preamble='src_units=( "$SRC_SYSTEMD_DIR"/a.service )')
+        assert r.returncode != 0
+        assert "WantedBy=extra.target but no enable symlink" in r.stdout
+        assert "\\" not in r.stdout.split("WantedBy=")[1][:20], f"literal backslash parsed as a target: {r.stdout!r}"
+
+    def test_comment_after_a_continuation_does_not_become_a_target(self, tmp_path):
+        """The shell normaliser's version of the same case."""
+        unit = PLAIN + "[Install]\nWantedBy=multi-user.target \\\n# trailing comment\n"
+        src, etc = _fake_tree(tmp_path, {"a.service": unit}, wants={"multi-user.target": ["a.service"]})
+        r = _run_smoke_block("enable-symlink-check", src, etc, preamble='src_units=( "$SRC_SYSTEMD_DIR"/a.service )')
+        assert r.returncode == 0, f"a legal unit was rejected: {r.stdout!r}"
+
+    def test_crlf_unit_is_parsed(self, tmp_path):
+        """`tr -d '\\r'` was in the shipped code and exercised by no fixture."""
+        unit = "[Unit]\r\nDescription=x\r\n[Install]\r\nWantedBy=multi-user.target\r\n"
+        src, etc = _fake_tree(tmp_path, {"a.service": unit}, wants={"multi-user.target": ["a.service"]})
+        r = _run_smoke_block("enable-symlink-check", src, etc, preamble='src_units=( "$SRC_SYSTEMD_DIR"/a.service )')
+        assert r.returncode == 0, r.stdout
+
+    def test_wantedby_outside_the_install_section_is_ignored(self, tmp_path):
+        """The scoping the shipped comment justifies. Replacing the sed range
+        with `cat "$src"` left every other test green, so a decoy WantedBy= in
+        [Unit] proves the scope is real."""
+        unit = "[Unit]\nWantedBy=decoy.target\n[Service]\nExecStart=/bin/true\n[Install]\nWantedBy=multi-user.target\n"
+        src, etc = _fake_tree(tmp_path, {"a.service": unit}, wants={"multi-user.target": ["a.service"]})
+        r = _run_smoke_block("enable-symlink-check", src, etc, preamble='src_units=( "$SRC_SYSTEMD_DIR"/a.service )')
+        assert r.returncode == 0, f"decoy WantedBy= in [Unit] leaked into the check: {r.stdout!r}"
+        assert "decoy.target" not in r.stdout
+
+    def test_excluded_unit_left_disabled_passes(self, tmp_path):
+        """The POSITIVE exclusion path. Deleting the `continue` after the
+        exclusion probe hard-fails every real build ~40 minutes in, and no test
+        covered it — only the strictness was pinned, not the tolerance."""
+        unit = PLAIN + "[Install]\nWantedBy=timers.target\n"
+        src, etc = _fake_tree(tmp_path, {"litclock.timer": unit}, wants={"timers.target": ["someone-else.service"]})
+        r = _run_smoke_block(
+            "enable-symlink-check", src, etc, preamble='src_units=( "$SRC_SYSTEMD_DIR"/litclock.timer )'
+        )
+        assert r.returncode == 0, r.stdout
+
+    def test_unit_without_install_section_is_skipped(self, tmp_path):
+        """The other tolerance `continue`. Deleting
+        `grep -q '^\\[Install\\]' || continue` hard-fails every build; 8 of our
+        units have no [Install] section."""
+        src, etc = _fake_tree(tmp_path, {"a.service": PLAIN})
+        r = _run_smoke_block("enable-symlink-check", src, etc, preamble='src_units=( "$SRC_SYSTEMD_DIR"/a.service )')
+        assert r.returncode == 0, r.stdout
+
+    def test_empty_src_units_fails_instead_of_passing_vacuously(self, tmp_path):
+        """src_units is set in a DIFFERENT sentinel block 70 lines up. If it is
+        ever empty every loop here is a no-op and the section prints its success
+        line having verified nothing. The harness injects its own src_units for
+        every other case, so without this the dependency is covered nowhere."""
+        src, etc = _fake_tree(tmp_path, {"a.service": INSTALLED_UNIT})
+        r = _run_smoke_block("enable-symlink-check", src, etc, preamble="src_units=( )")
+        assert r.returncode != 0
+        assert "src_units is empty" in r.stdout
+
+    def test_success_line_does_not_claim_units_it_did_not_verify(self, tmp_path):
+        """The NOTE was printed and the very next line still said "every
+        [Install] unit enabled". A build log that contradicts itself one line
+        later is a log nobody reads twice."""
+        src, etc = _fake_tree(tmp_path, {"a.service": PLAIN + "[Install]\nAlias=other.service\n"})
+        r = _run_smoke_block("enable-symlink-check", src, etc, preamble='src_units=( "$SRC_SYSTEMD_DIR"/a.service )')
+        assert r.returncode == 0
+        assert "1 unit(s) NOT verified" in r.stdout
+        assert "OK: every [Install] unit enabled" not in r.stdout
+
+    def test_success_line_is_unqualified_when_everything_was_verified(self, tmp_path):
+        src, etc = _fake_tree(tmp_path, {"a.service": INSTALLED_UNIT}, wants={"multi-user.target": ["a.service"]})
+        r = _run_smoke_block("enable-symlink-check", src, etc, preamble='src_units=( "$SRC_SYSTEMD_DIR"/a.service )')
+        assert r.returncode == 0
+        assert "OK: every [Install] unit enabled" in r.stdout
+        assert "NOT verified" not in r.stdout
+
+    def test_multi_target_wantedby_requires_every_target(self, tmp_path):
+        """WantedBy=a.target b.target enables into BOTH; checking only the first
+        would half-verify it."""
+        unit = PLAIN + "[Install]\nWantedBy=multi-user.target extra.target\n"
+        # extra.target.wants EXISTS and holds another unit — see the note on
+        # test_install_unit_missing_its_symlink_fails.
+        src, etc = _fake_tree(
+            tmp_path,
+            {"a.service": unit},
+            wants={"multi-user.target": ["a.service"], "extra.target": ["someone-else.service"]},
+        )
+        r = _run_smoke_block("enable-symlink-check", src, etc, preamble='src_units=( "$SRC_SYSTEMD_DIR"/a.service )')
+        assert r.returncode != 0
+        # The discriminating form. Bare `"extra.target" in stdout` also passes if
+        # word-splitting regressed and the loop iterated the single token
+        # "multi-user.target extra.target" — failing for the wrong reason.
+        assert "WantedBy=extra.target but no enable symlink" in r.stdout
+        assert "WantedBy=multi-user.target extra.target" not in r.stdout
+
+
+_ANALYZE_STUB = r"""#!/bin/bash
+# Stand-in for systemd-analyze. Emits whatever ANALYZE_OUT holds and exits
+# ANALYZE_RC, so the classification logic can be exercised without systemd.
+# STDERR, not stdout. systemd-analyze writes ALL diagnostics to stderr and
+# nothing to stdout (verified on 255), so a stub printing to stdout exercised a
+# stream the real tool never uses — and deleting the shipped `2>&1` left every
+# test in TestUnitSyntaxCheck green while the gate became a no-op.
+printf '%s\n' "$ANALYZE_OUT" >&2
+exit "${ANALYZE_RC:-0}"
+"""
+
+
+def _run_syntax_check(tmp_path, out, rc, units=("a.service",)):
+    """Run 05's unit-syntax-check block against a stubbed systemd-analyze."""
+    bindir = tmp_path / "analyzebin"
+    bindir.mkdir(exist_ok=True)
+    stub = bindir / "systemd-analyze"
+    stub.write_text(_ANALYZE_STUB)
+    stub.chmod(0o755)
+    src = tmp_path / "src"
+    src.mkdir(exist_ok=True)
+    for u in units:
+        (src / u).write_text(PLAIN)
+    listing = " ".join(f'"{src}/{u}"' for u in units)
+    script = "set -e\n" + f"src_units=( {listing} )\n" + _extract_smoke_block("unit-syntax-check") + "\n"
+    env = {
+        **os.environ,
+        "PATH": f"{bindir}:{os.environ['PATH']}",
+        "ANALYZE_OUT": out,
+        "ANALYZE_RC": str(rc),
+    }
+    return subprocess.run(["bash", "-c", script], capture_output=True, text=True, timeout=15, env=env)
+
+
+class TestUnitSyntaxCheck:
+    """Widening this loop from 7 hardcoded units to the whole tree made it
+    receive the litclock-dev#547 evidence — and it was throwing it away.
+
+    `systemd-analyze verify` reports "Command ... is not executable" for an
+    ExecStart= whose target never reached the image. That message matched none of
+    fatal_patterns, so the loop printed "(warnings only — not fatal)" and then
+    "OK: all unit files pass". Five helpers referenced by units are in no
+    required_files entry, so nothing else in the file would have noticed.
+    """
+
+    def test_clean_run_passes(self, tmp_path):
+        r = _run_syntax_check(tmp_path, "", 0)
+        assert r.returncode == 0, r.stdout
+        assert "OK: all unit files pass" in r.stdout
+
+    def test_parse_error_is_fatal(self, tmp_path):
+        r = _run_syntax_check(tmp_path, "a.service: Failed to parse Unit section", 1)
+        assert r.returncode != 0
+        assert "has real errors" in r.stdout
+
+    @pytest.mark.parametrize(
+        "message",
+        [
+            "a.service: Command /usr/local/lib/litclock/litclock-set-timezone is not executable: Permission denied",
+            "a.service: Command /usr/local/bin/missing.sh: No such file or directory",
+        ],
+    )
+    def test_missing_or_non_executable_command_is_fatal(self, tmp_path, message):
+        """The litclock-dev#547 shape: the unit shipped, the thing it runs did not. On the
+        device this is status=203/EXEC in a journal nobody reads."""
+        r = _run_syntax_check(tmp_path, message, 1)
+        assert r.returncode != 0, f"missing ExecStart target was treated as a warning: {r.stdout!r}"
+        assert "missing or not executable" in r.stdout
+
+    def test_classifies_on_output_even_when_the_exit_code_is_zero(self, tmp_path):
+        """THE bug this loop had. `systemd-analyze verify` exits ZERO for
+        config-parse warnings — verified on systemd 255, a unit containing
+        `WnatedBy=multi-user.target` (the literal litclock-dev#547 typo) produces
+        `Unknown key name 'WnatedBy' in section 'Install', ignoring.` with rc=0.
+
+        The old `if output=$(...); then :; else <classify>; fi` therefore never
+        reached the classifier for it: nothing echoed, neither pattern
+        consulted, the counter not incremented, and the success line printed.
+        The exit code is not a classifier."""
+        r = _run_syntax_check(tmp_path, "a.service:7: Unknown key name 'WnatedBy' in section 'Install', ignoring.", 0)
+        assert r.returncode != 0, (
+            f"rc=0 output was not classified — the gate is unreachable for the litclock-dev#547 typo: {r.stdout!r}"
+        )
+        assert "has real errors" in r.stdout
+
+    def test_unknown_key_name_is_fatal(self, tmp_path):
+        """`Unknown key name` is the wording systemd has used since v246;
+        bookworm ships 252. `Unknown lvalue` alone is pre-246 and matches
+        nothing on any Pi we ship."""
+        # Read the ASSIGNMENT, not the file: "Unknown key name" also appears in
+        # the rationale comment above it, so a whole-file substring search passed
+        # even with the pattern deleted from fatal_patterns.
+        body = open(SMOKE_TEST_SH).read()
+        m = re.search(r"^fatal_patterns='([^']*)'", body, re.MULTILINE)
+        assert m, "fatal_patterns assignment not found"
+        assert "Unknown key name" in m.group(1), "fatal_patterns is missing the message systemd emits since v246"
+
+    def test_a_bare_errno_is_not_treated_as_a_missing_command(self, tmp_path):
+        """exec_fatal_patterns is anchored to `Command .* is not executable`, not
+        the bare errno. Unanchored, ANY chroot-level failure carrying
+        `No such file or directory` (dbus, /proc, machine-id) hard-fails every
+        unit 38 minutes into a 40-minute build."""
+        r = _run_syntax_check(tmp_path, "Failed to connect to bus: No such file or directory", 0)
+        assert r.returncode == 0, f"a bare errno was treated as fatal: {r.stdout!r}"
+        assert "missing or not executable" not in r.stdout
+
+    def test_verifier_failing_with_no_output_is_not_a_pass(self, tmp_path):
+        """rc!=0 with empty output means the VERIFIER died — under
+        qemu-user-static a signal death gives rc=132/139 and prints nothing.
+        Discarding rc laundered that into `OK: all unit files pass`."""
+        r = _run_syntax_check(tmp_path, "", 1)
+        assert r.returncode != 0, f"verifier failure reported as success: {r.stdout!r}"
+        assert "OK: all unit files pass" not in r.stdout
+
+    def test_a_warning_with_rc_zero_is_still_counted(self, tmp_path):
+        """Non-fatal output on a zero exit must still suppress the unqualified
+        success line."""
+        r = _run_syntax_check(tmp_path, "a.service: Unit is bound to inactive device", 0)
+        assert r.returncode == 0, r.stdout
+        assert "non-fatal warnings" in r.stdout
+        assert "OK: all unit files pass" not in r.stdout
+
+    def test_genuine_warning_is_counted_not_hidden(self, tmp_path):
+        """A non-fatal warning must not be laundered into an unqualified
+        "all unit files pass" — the success line has to reflect that a unit
+        printed output."""
+        r = _run_syntax_check(tmp_path, "a.service: Unit is bound to inactive device", 1)
+        assert r.returncode == 0, r.stdout
+        assert "non-fatal warnings" in r.stdout
+        assert "OK: all unit files pass" not in r.stdout
+
+
+TMPFILES_BODY = "d /run/litclock 0755 pi pi -\n"
+
+
+def _fake_tmpfiles_tree(tmp_path, confs, installed=None):
+    """Miniature systemd/tmpfiles.d/ + /etc/tmpfiles.d/ pair."""
+    src = tmp_path / "tmpfiles.d"
+    etc = tmp_path / "etc-tmpfiles.d"
+    src.mkdir(exist_ok=True)
+    etc.mkdir(exist_ok=True)
+    for name, body in confs.items():
+        (src / name).write_text(body)
+    for name in confs if installed is None else installed:
+        (etc / name).write_text(confs[name])
+    return str(src), str(etc)
+
+
+def _run_tmpfiles_install_check(src_dir, etc_dir):
+    script = (
+        "set -e\n"
+        f'SRC_TMPFILES_DIR="{src_dir}"\n'
+        f'ETC_TMPFILES_DIR="{etc_dir}"\n'
+        f"{_extract_smoke_block('tmpfiles-install-check')}\n"
+    )
+    return subprocess.run(["bash", "-c", script], capture_output=True, text=True, timeout=15)
+
+
+class TestTmpfilesSmokeCheckFailsLoudly:
+    """The tmpfiles drop-in reaching the image is the difference between a
+    working clock and one that paints quotes while every piece of runtime state
+    silently no-ops. This loop is the only thing that catches it, so it has to
+    exit non-zero rather than print."""
+
+    def test_installed_and_matching_passes(self, tmp_path):
+        src, etc = _fake_tmpfiles_tree(tmp_path, {"litclock.conf": TMPFILES_BODY})
+        assert _run_tmpfiles_install_check(src, etc).returncode == 0
+
+    def test_dropin_never_installed_fails(self, tmp_path):
+        """litclock-dev#547's shape, in tmpfiles.d/: present in the repo, absent from
+        the image, and nothing on the device ever complains."""
+        src, etc = _fake_tmpfiles_tree(tmp_path, {"litclock.conf": TMPFILES_BODY}, installed=[])
+        r = _run_tmpfiles_install_check(src, etc)
+        assert r.returncode != 0
+        assert "never installed" in r.stdout
+
+    def test_installed_dropin_differing_from_source_fails(self, tmp_path):
+        """Stale drop-in from a reused CLEAN=0 work dir satisfies -e but
+        differs — an image shipping ownership rules nobody reviewed."""
+        src, etc = _fake_tmpfiles_tree(tmp_path, {"litclock.conf": TMPFILES_BODY})
+        (tmp_path / "etc-tmpfiles.d" / "litclock.conf").write_text("d /run/litclock 0755 root root -\n")
+        assert _run_tmpfiles_install_check(src, etc).returncode != 0
+
+    def test_empty_source_tree_fails(self, tmp_path):
+        src, etc = _fake_tmpfiles_tree(tmp_path, {})
+        r = _run_tmpfiles_install_check(src, etc)
+        assert r.returncode != 0
+        assert "repo staging is broken" in r.stdout
+
+    def test_second_dropin_is_covered_without_editing_the_check(self, tmp_path):
+        """The point of deriving rather than naming: adding a drop-in must be
+        covered automatically, or this is the hardcoded list again."""
+        src, etc = _fake_tmpfiles_tree(
+            tmp_path,
+            {"litclock.conf": TMPFILES_BODY, "extra.conf": "d /run/other 0755 pi pi -\n"},
+            installed=["litclock.conf"],
+        )
+        r = _run_tmpfiles_install_check(src, etc)
+        assert r.returncode != 0
+        assert "extra.conf" in r.stdout
 
 
 # ── Version metadata ─────────────────────────────────────────────────
-
-
-class TestPiGenVenvPosture:
-    """The #214/#321/#323 venv invariants, asserted against the IMAGE build.
-
-    These were previously covered for scripts/install.sh (tests/test_install_sh.py,
-    deleted with it in litclock-dev#547) and for scripts/update.sh
-    (tests/test_update_sh.py). Nothing ever read
-    pi-gen/stage3/01-setup-app/00-run.sh — which is where a flashed device
-    actually gets its venv.
-
-    Before litclock-dev#547 that was 2 of 3 install paths guarded. Retiring
-    install.sh would have left 1 of 2, with the unguarded one being the ONLY
-    path that ships. Review flagged it; retiring the mirror is the moment to
-    point the assertions at the survivor rather than lose them.
-    """
-
-    @staticmethod
-    def _setup_app():
-        with open(os.path.join(STAGE_DIR, "01-setup-app", "00-run.sh")) as f:
-            return f.read()
-
-    def test_venv_uses_system_site_packages(self):
-        """#214: the apt-provisioned GPIO/SPI wheels are only visible to the
-        venv with --system-site-packages. Without it the driver chain cannot
-        import lgpio and the panel never paints."""
-        body = self._setup_app()
-        assert "python3 -m venv --system-site-packages" in body, (
-            "pi-gen must create the venv with --system-site-packages (#214)"
-        )
-
-    def test_pip_install_filters_apt_provisioned_names(self):
-        """#214: requirements-apt.txt is the single source of truth for names
-        pip must NOT install. The filter builds EXCLUDE_RE from that file, so
-        a hand-edited list here would silently drift."""
-        # Comments stripped first: mutation showed `"requirements-apt.txt" in
-        # body` was satisfied by the explanatory comment above the code, so the
-        # executable line could stop reading the file and this stayed green.
-        body = _strip_comments(self._setup_app())
-        assert re.search(r"EXCLUDE_RE=.*requirements-apt\.txt", body), (
-            "pi-gen must build EXCLUDE_RE from requirements-apt.txt itself (#214) — "
-            "a hand-maintained list here is exactly the drift that file exists to prevent"
-        )
-        assert re.search(r"grep -vE .*EXCLUDE_RE.* requirements\.txt", body), (
-            "pi-gen must filter requirements.txt through EXCLUDE_RE before pip install"
-        )
-
-    def test_pip_install_is_not_eager(self):
-        """#322: eager upgrade-strategy silently bumps transitives fleet-wide;
-        the smoke test never imports Flask, so a break would ship."""
-        body = self._setup_app()
-        assert "--upgrade-strategy eager" not in body, (
-            "pi-gen must NOT use eager upgrade-strategy (#322) — transitive breaks ship unnoticed"
-        )
 
 
 class TestVersionMetadata:
@@ -360,3 +1714,73 @@ class TestJournaldConfig:
         """Size cap is required to prevent unbounded SD card wear."""
         content = self._read()
         assert re.search(r"^SystemMaxUse=\d+[KMG]?", content, re.MULTILINE)
+
+
+# ── venv posture on the path that actually ships ─────────────────────
+
+
+class TestPiGenVenvPosture:
+    """The #214/#321/#323 venv invariants, asserted against the IMAGE build.
+
+    These were previously covered for scripts/install.sh (tests/test_install_sh.py,
+    deleted with it in litclock-dev#547) and for scripts/update.sh (tests/test_update_sh.py).
+    Nothing ever read pi-gen/stage3/01-setup-app/00-run.sh — which is where a
+    flashed device actually gets its venv.
+
+    Before litclock-dev#547 that was 2 of 3 install paths guarded. Retiring install.sh
+    would have left 1 of 2, with the unguarded one being the ONLY path that
+    ships. Review flagged it; retiring the mirror is the moment to point the
+    assertions at the survivor rather than lose them.
+    """
+
+    @staticmethod
+    def _setup_app():
+        with open(os.path.join(STAGE_DIR, "01-setup-app", "00-run.sh")) as f:
+            return f.read()
+
+    def test_venv_uses_system_site_packages(self):
+        """#214: the apt-provisioned GPIO/SPI wheels are only visible to the
+        venv with --system-site-packages. Without it the driver chain cannot
+        import lgpio and the panel never paints."""
+        body = self._setup_app()
+        assert "python3 -m venv --system-site-packages" in body, (
+            "pi-gen must create the venv with --system-site-packages (#214)"
+        )
+
+    def test_pip_install_filters_apt_provisioned_names(self):
+        """#214: requirements-apt.txt is the single source of truth for names
+        pip must NOT install. The filter builds EXCLUDE_RE from that file, so
+        a hand-edited list here would silently drift."""
+        # Comments stripped first: mutation showed `"requirements-apt.txt" in
+        # body` was satisfied by the explanatory comment above the code, so the
+        # executable line could stop reading the file and this stayed green.
+        body = _strip_comments(self._setup_app())
+        assert re.search(r"EXCLUDE_RE=.*requirements-apt\.txt", body), (
+            "pi-gen must build EXCLUDE_RE from requirements-apt.txt itself (#214) — "
+            "a hand-maintained list here is exactly the drift that file exists to prevent"
+        )
+        assert re.search(r"grep -vE .*EXCLUDE_RE.* requirements\.txt", body), (
+            "pi-gen must filter requirements.txt through EXCLUDE_RE before pip install"
+        )
+
+    def test_pip_install_is_not_eager(self):
+        """#322: eager upgrade-strategy silently bumps transitives fleet-wide;
+        the smoke test never imports Flask, so a break would ship."""
+        body = self._setup_app()
+        assert "--upgrade-strategy eager" not in body, (
+            "pi-gen must NOT use eager upgrade-strategy (#322) — transitive breaks ship unnoticed"
+        )
+
+    def test_pip_installs_filtered_requirements_with_upgrade(self):
+        """#321 / litclock-dev#605 item 19: the deleted installer test pinned
+        `pip install --upgrade -r`; nothing re-pinned it against pi-gen. pip
+        without --upgrade may silently SKIP an already-satisfied pin — this
+        exact class has shipped before in this repo — and the
+        install must target the FILTERED file, not raw requirements.txt,
+        or the apt-provisioned GPIO stack gets shadowed by wheels."""
+        body = _strip_comments(self._setup_app())
+        assert re.search(r"venv/bin/pip install --upgrade -r \S*requirements-pigen", body), (
+            "pi-gen must `venv/bin/pip install --upgrade -r` the filtered requirements "
+            "file (#321/litclock-dev#605) — venv-pip specifically, a bare `pip` is the documented "
+            "wrong-interpreter pitfall class"
+        )

--- a/tests/test_update_sh.py
+++ b/tests/test_update_sh.py
@@ -12,6 +12,7 @@ Two layers of coverage:
    reaches the right phases and makes the expected subprocess calls.
 """
 
+import re
 from pathlib import Path
 
 import pytest
@@ -26,6 +27,21 @@ def update_sh_content():
 
 
 # ── Structural tests ──────────────────────────────────────────────────
+
+
+def _tmpfiles_block(content):
+    """The tmpfiles install block, delimited by real anchors.
+
+    Was a fixed 2600-character slice, which is a magic number masquerading as a
+    boundary: adding a comment inside the block silently pushed the tail out of
+    the window and the assertions started reading truncated text. Anchor on the
+    counter that opens the block and the next section that follows it.
+    """
+    start = content.find("tmpfiles_installed=0")
+    assert start != -1, "tmpfiles install counter missing"
+    end = content.find("if [[ ${#ENABLED_UNITS[@]}", start)
+    assert end != -1, "could not find the section following the tmpfiles block"
+    return content[start:end]
 
 
 class TestUpdateScriptStructure:
@@ -81,6 +97,93 @@ class TestUpdateScriptStructure:
         assert "*.service" not in loop_body, (
             "loop must NOT match *.service — services are timer-driven or have their own start hooks"
         )
+
+    def test_tmpfiles_dropins_are_globbed_not_named(self, update_sh_content):
+        """litclock-dev#547's shape on the OTA path. This was
+        `if [[ -f .../tmpfiles.d/litclock.conf ]]; then sudo cp ...` — a
+        hand-maintained name behind a soft `if`, so a second drop-in would
+        never reach a fielded Pi and a missing one skipped with no journal
+        line. pi-gen/stage3/03-install-services globs; so must this."""
+        assert 'for conf in "$INSTALL_DIR"/systemd/tmpfiles.d/*.conf' in update_sh_content, (
+            "update.sh must glob systemd/tmpfiles.d/ rather than naming litclock.conf"
+        )
+        hardcoded = re.findall(
+            r"^\s*(?:sudo\s+)?cp\b[^\n]*?/systemd/tmpfiles\.d/[\w.\-]+\.conf",
+            update_sh_content,
+            re.MULTILINE,
+        )
+        assert not hardcoded, f"per-file cp of a tmpfiles drop-in reintroduced: {hardcoded}"
+
+    def test_missing_tmpfiles_dropins_warn_rather_than_skip_silently(self, update_sh_content):
+        """A glob that matches nothing exits 0. The old soft `if` reported
+        nothing in that case; an OTA that silently stops refreshing the rules
+        for /run/litclock and /var/lib/litclock must at least say so."""
+        block = _tmpfiles_block(update_sh_content)
+        assert re.search(r"if \[\[ \$tmpfiles_seen -eq 0 \]\]", block), "no zero-drop-in check after the tmpfiles glob"
+        assert "log_warn" in block.split("tmpfiles_seen -eq 0")[1][:400], (
+            "the zero-drop-in case must log_warn, not pass silently"
+        )
+
+    def test_tmpfiles_glob_is_paired_with_nullglob(self, update_sh_content):
+        """Without `shopt -s nullglob` an unmatched glob stays LITERAL, so the
+        copy fails on a path containing `*`, and — because update.sh has no
+        errexit — the loop body still runs once. Verified defeat: deleting the
+        shopt left the other tests green while making the zero-drop-in warning
+        unreachable, i.e. the new guard reported success having installed
+        nothing. Restore is save/restore, not a blind `shopt -u`, so a future
+        `shopt -s nullglob` earlier in this 1400-line script is not silently
+        cleared for every later phase."""
+        block = _tmpfiles_block(update_sh_content)
+        assert "shopt -s nullglob" in block, "the tmpfiles glob is not guarded by nullglob"
+        assert "_ng_saved=$(shopt -p nullglob)" in block, "nullglob must be saved before being set"
+        assert 'eval "$_ng_saved"' in block, "nullglob must be RESTORED, not blindly cleared"
+
+    def test_tmpfiles_copy_failure_is_checked_before_counting(self, update_sh_content):
+        """The counter must not advance on a failed privileged copy.
+
+        update.sh has no errexit, so an unchecked `cp` left the PREVIOUS
+        release's drop-in in place, `systemd-tmpfiles --create` then succeeded
+        against that stale file so its own `|| log_warn` never fired, the
+        counter read non-zero so the zero-drop-in warning never fired either,
+        and the OTA reported success having installed nothing — on the only path
+        that touches already-working clocks.
+        """
+        block = _tmpfiles_block(update_sh_content)
+        assert re.search(r"if ! sudo install -m 0644 -o root -g root \"\$conf\" /etc/tmpfiles\.d/; then", block), (
+            "the tmpfiles copy must be failure-checked before the counter advances"
+        )
+        # The increment must come AFTER the guarded copy, not before it.
+        copy_at = block.find("if ! sudo install -m 0644")
+        inc_at = block.find("tmpfiles_installed=$(( tmpfiles_installed + 1 ))")
+        assert copy_at != -1 and inc_at > copy_at, "counter increments before the copy is verified"
+
+    def test_tmpfiles_and_units_are_installed_not_cp(self, update_sh_content):
+        """`install -m 0644 -o root -g root`, matching pi-gen's 03. `cp` applies
+        the SOURCE mode, so a drop-in committed 0755 or 0600 landed correctly on
+        a flashed image and incorrectly on every OTA'd Pi — a divergence only
+        reproducible on the fielded fleet, which is the one configuration QA
+        never covers."""
+        block = _tmpfiles_block(update_sh_content)
+        assert not re.search(r"sudo cp \"\$conf\"", block), "tmpfiles drop-ins are still copied with plain cp"
+
+    def test_tmpfiles_rejects_non_regular_files(self, update_sh_content):
+        """$INSTALL_DIR is pi-writable and `cp`/`install` dereference the source,
+        so a symlink here would make the sudo below read an arbitrary path and
+        write it into /etc/tmpfiles.d/, which root systemd-tmpfiles parses at
+        every boot. pi-gen's 03 rejects these explicitly; this path did not."""
+        block = _tmpfiles_block(update_sh_content)
+        assert re.search(r'\[\[ ! -f "\$conf" \|\| -L "\$conf" \]\]', block), (
+            "no regular-file/symlink guard before the privileged tmpfiles copy"
+        )
+
+    def test_failed_enable_is_not_recorded_as_newly_enabled(self, update_sh_content):
+        """ENABLED_UNITS drives the "Newly enabled" log line and the end-of-run
+        summary. With no errexit, a failed `systemctl enable` used to fall
+        through and still append, so the OTA reported a new timer as enabled
+        while it stayed disabled — nothing runs, nothing complains."""
+        assert re.search(
+            r"if sudo systemctl enable \"\$name\"; then\s*\n\s*ENABLED_UNITS\+=\(\"\$name\"\)", update_sh_content
+        ), "ENABLED_UNITS must only record units whose `systemctl enable` actually succeeded"
 
     def test_timer_start_after_daemon_reload(self, update_sh_content):
         """The new-timer-start loop must run AFTER `systemctl daemon-reload`
@@ -1196,3 +1299,63 @@ def test_migrates_handoff_complete_for_existing_devices():
     src = UPDATE_SH.read_text()
     assert "/etc/litclock/.handoff-complete" in src
     assert "sudo touch /etc/litclock/.handoff-complete" in src
+
+
+class TestRuntimeMarkerInvalidation:
+    """litclock-dev#604 — the validation marker is gitignored, so the
+    Phase-2 git reset never touches it; update.sh itself must remove it
+    when any proof input changed in the release being applied."""
+
+    def test_marker_removal_block_exists_with_every_proof_input(self):
+        src = UPDATE_SH.read_text()
+        assert ".runtime-render-validated" in src
+        block_start = src.index("RUNTIME_MARKER=")
+        block = src[block_start : src.index("Remove old systemd units", block_start)]
+        # The delete is gated on the diff of the proof inputs, not unconditional.
+        assert "git diff --quiet" in block
+        for proof_input in (
+            "fonts/",
+            "tools/gd-expected-measurements.json.gz",
+            "requirements.txt",
+            "src/quote_renderer.py",
+            "src/gd_measure.py",
+            "tools/validate_measurement.py",
+        ):
+            assert proof_input in block, f"{proof_input} missing from the invalidation trigger set"
+        assert 'rm -f "$RUNTIME_MARKER"' in block
+
+    def test_marker_removal_runs_after_the_git_reset(self):
+        """The diff needs the NEW tree (and NEW_SHA) to exist — before the
+        reset it would compare the wrong states and the marker would
+        survive the exact updates that invalidate it."""
+        src = UPDATE_SH.read_text()
+        assert src.index('NEW_SHA=$(git rev-parse --short HEAD)') < src.index("RUNTIME_MARKER=")
+
+    def test_marker_removal_diffs_old_to_new(self):
+        src = UPDATE_SH.read_text()
+        block = src[src.index("RUNTIME_MARKER=") :]
+        assert '"$OLD_SHA" "$NEW_SHA"' in block.split("Remove old systemd units")[0]
+
+    def test_marker_path_honors_the_env_override(self):
+        """litclock-dev#611 review — the reader honors
+        LITCLOCK_RUNTIME_VALIDATED_MARKER (via env.sh); update.sh must
+        resolve the same path or a relocated marker silently survives the
+        only invalidation layer covering semantics-only proof changes."""
+        src = UPDATE_SH.read_text()
+        start = src.index("RUNTIME_MARKER=")
+        block = src[start : src.index("Remove old systemd units", start)]
+        assert "LITCLOCK_RUNTIME_VALIDATED_MARKER" in block
+        assert 'source "$INSTALL_DIR/env.sh"' in block
+
+    def test_git_diff_failure_also_removes_the_marker_with_an_honest_log(self):
+        """A gc'd SHA or corrupt object makes git diff exit >1 under
+        2>/dev/null. We cannot PROVE the inputs unchanged, so the marker
+        still goes (wrong fallback beats wrong render) — but under its own
+        log line, not the 'inputs changed' claim."""
+        src = UPDATE_SH.read_text()
+        start = src.index("RUNTIME_MARKER=")
+        block = src[start : src.index("Remove old systemd units", start)]
+        assert "_marker_diff_rc" in block
+        assert "-gt 1" in block
+        assert block.count('rm -f "$RUNTIME_MARKER"') == 2
+        assert "could not verify" in block


### PR DESCRIPTION
Closes #46 — fresh flashes never installed `litclock-reresolve-location.service`, so an Automatic-mode clock that moved (VPN egress change, relocation, gifting) did not re-resolve its timezone/city on boot. Update-path devices were fine (`update.sh` auto-enables new units); only the fresh-flash path — the one a gift recipient takes — was affected, including the shipping v0.223.0 image.

## The fix

Root cause was a hand-maintained cp/enable list in `pi-gen/stage3/03-install-services/00-run.sh` that drifted from `systemd/`. This ports the dev-side fix: the install-services copy and the smoke-test verification are now globbed loops derived from `systemd/` (+ a tmpfiles loop), so a new unit can never silently miss the image again. `litclock-reresolve-location.service` is now copied by the glob and explicitly enabled; the derived-guard tests (`test_reresolve_location_is_enabled`, `test_every_install_unit_is_enabled_or_explicitly_excluded`) make this class of omission fail CI.

## Folded in (the ported tests depend on them)

- **Image-correctness pytest gate in the build workflow**, BEFORE the ~40-min build (`test_pi_gen` + `test_build_image_workflow`) — a broken unit tree fails in ~1 min, not at minute 38.
- **Workflow hardening**: dispatch inputs reach shells via `env:` not inline `${{ }}` (template-injection surface on a release-signing runner); release `--target` uses the resolved full SHA (not `github.sha`), so a dispatch build is traceable to the code inside it; `persist-credentials: false` on the build checkout; checkout pinned v7.0.1 in both jobs.
- **Drop the unused pytz pin** (requirements + smoke-test + dry-run import check) so the ported smoke-test/update.sh import lines stay coherent.
- **update.sh runtime-render marker invalidation** (needed by the ported `TestRuntimeMarkerInvalidation`).

## Public-only content preserved through the merge

- The **promote job** (build-once-ship-what-you-tested release flow) + its `promote_from`/`release_version` inputs + the `build.if` gate.
- The **#527 sysctl `cmp -s`** drop-in verification in `update.sh`.

## Review

Ported mechanically (dev files, ref-requalified to `litclock-dev#NNN`), then reviewed before opening: a port-verification pass (every divergence from dev is ref-requalification or preserved public-only content — nothing clobbered, no wrongly-requalified ref, graft coherent) and a Codex adversarial pass.

**One finding, inherited from dev — NOT introduced here (filed as litclock-dev#617):** the build job writes `LITCLOCK_REF=${REF}` / `LITCLOCK_VERSION=${VERSION}` into `pi-gen/config`, which `04-finalize` sources — a crafted tag/branch name (git allows `;`/`$()` in refnames) would execute when sourced. Byte-identical to dev master, reachable only with repo-write. The mechanical port ships the dev-identical form; the fix (`printf %q` or a refname allowlist) lands dev-first and ports separately, keeping this PR mechanical.

## Gate

ruff clean · shellcheck clean (pre-existing SC2015/SC1091 info only) · 2,991 pytest pass · workflow YAML validated (build + promote jobs, `promote_from` gate).