### PR TITLE
fix(wifi): port the provisioning, retry, and splash train from litclock-dev

### DIFF
--- a/scripts/first-boot.sh
+++ b/scripts/first-boot.sh
@@ -104,26 +104,64 @@ update_issue_hotspot() {
         sudo cp /etc/issue /etc/issue.bak 2>/dev/null || true
     fi
 
-    # Pad values to fixed width so the box border aligns
-    local line_ssid line_pass line_ip
-    # Wording tracks the e-ink panel deliberately: a reader who plugs in a
-    # monitor is looking at the same two credentials the panel shows, and
-    # "Clock's Password:" is the exact string non-technical readers stored
-    # instead of typing. Field widths keep each line at the 43 chars it
-    # already rendered, so this changes no alignment.
-    line_ssid=$(printf "  LitClock's WiFi network: %-16s" "$ssid")
-    line_pass=$(printf "  LitClock's WiFi password: %-15s" "$password")
-    line_ip=$(printf "  Setup URL: %-23s" "http://${ip}:8080")
+    # Box width is derived from the content, floored at 45 so the shipped-path
+    # box (default 14-char SSID, 8-char password, IPv4 URL) stays byte-for-byte
+    # what it was. litclock-dev#589 item 4 fixed the border overflowing the
+    # fixed-width fields; litclock-dev#626 closes the residual gap — the old
+    # %-16s/%-15s/%-30s fields PADDED but never GREW, so any value longer than
+    # its field (a 32-char --ssid, a 63-char password, a non-IPv4 ip) broke the
+    # right border again. Growing the box keeps the border aligned for every
+    # value wifi_provision's boundary validation admits, without truncating —
+    # this banner exists so a tester can read the EXACT credentials.
+    # The char-count arithmetic below (${#var} vs printf byte-width padding)
+    # is only coherent because the validator restricts credentials to
+    # printable ASCII, where chars == bytes == terminal columns. A 63-char
+    # password grows the box past 80 columns and wraps on a narrow console —
+    # accepted: exactness over truncation, custom-credential path only.
+    # Wording tracks the e-ink panel deliberately.
+    # agetty interprets backslash escapes in /etc/issue (\d date, \l tty,
+    # \e ESC...). A credential containing a backslash — printable ASCII, so
+    # the validator admits it — would DISPLAY as something other than itself
+    # (the exact divergence litclock-dev#626 exists to prevent), and \e is
+    # terminal-escape injection into the login console. Double every
+    # backslash so getty renders the literal credential. Alignment for such
+    # values degrades gracefully (the file holds \\ = 2 cols, getty shows
+    # \ = 1): an honest credential beats a perfect border. Shipped-path
+    # values never contain backslashes, so this is a no-op there.
+    ssid="${ssid//\\/\\\\}"
+    password="${password//\\/\\\\}"
+    ip="${ip//\\/\\\\}"
+
+    local c_ssid c_pass c_ip title
+    c_ssid="  LitClock's WiFi network: ${ssid}"
+    c_pass="  LitClock's WiFi password: ${password}"
+    c_ip="  Setup URL: http://${ip}:8080"
+    title="LitClock WiFi Setup"
+
+    local interior=45 line
+    for line in "$c_ssid" "$c_pass" "$c_ip"; do
+        # +2 keeps the two trailing spaces the fixed template had
+        if (( ${#line} + 2 > interior )); then
+            interior=$(( ${#line} + 2 ))
+        fi
+    done
+
+    local border pad_l pad_r
+    # sed, not tr: tr is byte-wise and would emit only the first byte of the
+    # multibyte ═ per space, producing invalid UTF-8
+    border=$(printf '%*s' "$interior" '' | sed 's/ /═/g')
+    pad_l=$(( (interior - ${#title}) / 2 ))
+    pad_r=$(( interior - ${#title} - pad_l ))
 
     sudo tee /etc/issue > /dev/null << ISSUEEOF
 
-  ╔══════════════════════════════════════╗
-  ║       LitClock WiFi Setup            ║
-  ╠══════════════════════════════════════╣
-  ║${line_ssid}  ║
-  ║${line_pass}  ║
-  ║${line_ip}  ║
-  ╚══════════════════════════════════════╝
+  ╔${border}╗
+  ║$(printf '%*s%s%*s' "$pad_l" '' "$title" "$pad_r" '')║
+  ╠${border}╣
+  ║$(printf '%-*s' "$interior" "$c_ssid")║
+  ║$(printf '%-*s' "$interior" "$c_pass")║
+  ║$(printf '%-*s' "$interior" "$c_ip")║
+  ╚${border}╝
 
   Connect to the WiFi network above,
   then open the Setup URL in your browser.

--- a/src/eink_display.py
+++ b/src/eink_display.py
@@ -39,6 +39,11 @@ FONT_PATH_BOLD = os.path.join(PROJECT_ROOT, "fonts", "Literata72pt-Black.ttf")
 # baseline. Promoted from function-local vars so future layout tweaks have
 # one place to change.
 HOTSPOT_INFO_LINE_HEIGHT = 28
+# Point size of the setup splash's small text (framing line + numbered steps).
+# Hoisted so the step-line clamp tests measure with the SAME size production
+# draws at — a hardcoded 18 in the test would silently validate the wrong
+# font after a size tweak here (litclock-dev#629 review).
+SETUP_SMALL_FONT_PT = 18
 HOTSPOT_INFO_BOTTOM_PADDING = 20
 
 # QR block geometry for the setup splash. Module level for the same reason
@@ -130,11 +135,12 @@ def create_qr_display_image(url: str, title: str = None, caption: str = None, qr
         title_font = ImageFont.truetype(FONT_PATH_BOLD, 36)
         caption_font = ImageFont.truetype(FONT_PATH, 24)
         small_font = ImageFont.truetype(FONT_PATH, 18)
-    except Exception:
-        # Fallback to default font
-        title_font = ImageFont.load_default()
-        caption_font = ImageFont.load_default()
-        small_font = ImageFont.load_default()
+    except Exception as e:
+        # size= + log, never a silent 10px collapse (litclock-dev#589 item 3).
+        logging.error("fonts unavailable (%s); using scaled default", e)
+        title_font = ImageFont.load_default(size=36)
+        caption_font = ImageFont.load_default(size=24)
+        small_font = ImageFont.load_default(size=18)
 
     # Calculate positions
     qr_x = (DISPLAY_SIZE[0] - qr_size) // 2
@@ -288,15 +294,19 @@ def _fit_title(text: str, font_path: str, max_width: int) -> tuple[list[str], "I
     if not text:
         try:
             return [], ImageFont.truetype(font_path, TITLE_FIT_TIERS[0][0])
-        except Exception:
-            return [], ImageFont.load_default()
+        except Exception as e:
+            # size=, never a silent 10px collapse (litclock-dev#589 item 3).
+            logging.error("title font unavailable (%s); using scaled default", e)
+            return [], ImageFont.load_default(size=TITLE_FIT_TIERS[0][0])
 
     last: tuple[list[str], ImageFont.FreeTypeFont, int] | None = None
     for size, max_lines in TITLE_FIT_TIERS:
         try:
             font = ImageFont.truetype(font_path, size)
-        except Exception:
-            font = ImageFont.load_default()
+        except Exception as e:
+            # size=, matching this tier, never the silent 10px (litclock-dev#589 item 3).
+            logging.error("title font unavailable at %dpt (%s); using scaled default", size, e)
+            font = ImageFont.load_default(size=size)
         # Natural wrap: max_lines=len(text)+1 can never truncate, so this is the
         # untruncated line count at this font size.
         natural = _wrap_title(text, font, max_width, len(text) + 1)
@@ -329,9 +339,11 @@ def create_status_image(title: str, message: str = None, submessage: str = None)
     try:
         message_font = ImageFont.truetype(FONT_PATH, 28)
         small_font = ImageFont.truetype(FONT_PATH, 20)
-    except Exception:
-        message_font = ImageFont.load_default()
-        small_font = ImageFont.load_default()
+    except Exception as e:
+        # size= + log, never a silent 10px collapse (litclock-dev#589 item 3).
+        logging.error("fonts unavailable (%s); using scaled default", e)
+        message_font = ImageFont.load_default(size=28)
+        small_font = ImageFont.load_default(size=20)
 
     # litclock-dev#319 + litclock-dev#280 gift-message fix: word-wrap the title at the TITLE_SIDE_MARGIN
     # gutter, AUTO-FITTING the font so a long personalized welcome shrinks to
@@ -420,6 +432,12 @@ def display_image(image: Image.Image, epd=None):
 
 
 HOTSPOT_RETRY_WIFI_PASSWORD = "wifi_password"
+# litclock-dev#603 — the retry splash for every NON-password failure class
+# (timeout, network not found, anything else). The old behavior painted the
+# wrong-password variant for all of them, and its "select your network from
+# the list" step is exactly wrong for a hidden network that failed on
+# reachability. Same class-neutral title; the steps differ.
+HOTSPOT_RETRY_CONNECT_FAILED = "connect_failed"
 
 
 # ── Setup-splash copy ────────────────────────────────────────────────
@@ -469,8 +487,58 @@ SETUP_LABEL_PASSWORD = "LitClock's WiFi password:"
 SETUP_FRAMING_LINE = "The clock makes its own WiFi for setup."
 
 
-def setup_instruction_lines(ip: str, is_retry: bool = False) -> list[str]:
+def _sanitize_render_text(value: str | None, field: str) -> str:
+    """Strip control characters (including newlines) from a credential before
+    it is drawn on the setup splash (litclock-dev#589). This renderer treats
+    its args as constants, but wifi_provision honours ``--ssid`` and a newline
+    in the SSID would render multiline and collide with the password label.
+    Logs when it changes the value so a misconfigured credential is never
+    silently mangled."""
+    if not value:
+        return ""
+    text = str(value)
+    # str.isprintable() keeps ASCII space and every genuinely-printable glyph
+    # (accented letters, emoji) while dropping ALL Unicode Other/Separator code
+    # points — C0 AND C1 controls, DEL, NEL, the line/paragraph separators
+    # U+2028/U+2029, zero-width and bidi format chars. A plain `32 <= ord < 127`
+    # range would miss the C1 + Unicode-separator class (/review).
+    cleaned = "".join(ch for ch in text if ch == " " or ch.isprintable())
+    if cleaned != text:
+        logging.warning("setup splash %s contained control characters; stripped for rendering", field)
+    return cleaned
+
+
+def _wifi_qr_escape(value: str) -> str:
+    r"""Backslash-escape the ``WIFI:`` QR payload's reserved characters
+    ``\ ; , : "`` per the de-facto WIFI-QR format (litclock-dev#589).
+    Unreachable with the alnum password generator and the constant SSID, but a
+    varying input would otherwise silently encode the WRONG network onto the
+    phone that scans it."""
+    return "".join("\\" + ch if ch in '\\;,:"' else ch for ch in value)
+
+
+def _clamp_to_width(text: str, font, draw, max_w: int, field: str) -> str:
+    """Single-line fit-with-ellipsis at ``max_w`` px, logging when it truncates
+    so a clipped credential is never silent (litclock-dev#589). Reuses the
+    handoff splash's fit logic (_fit_ssid_to_band)."""
+    fitted = _fit_ssid_to_band(text, font, draw, max_w, max_lines=1)
+    result = fitted[0] if fitted else ""
+    if result != text:
+        logging.warning("setup splash %s too wide for the panel; truncated to fit", field)
+    return result
+
+
+def setup_instruction_lines(
+    ip: str, ssid: str = "LitClock-Setup", is_retry: bool = False, retry_reason: str | None = None
+) -> list[str]:
     """Bottom instruction block for the setup splash.
+
+    ``ssid`` names the network in the numbered steps. It MUST be the same value
+    create_hotspot_display_image paints in the credential block — a step that
+    says "join LitClock-Setup" while the credential block shows a different
+    network name is unreadable to the very audience (litclock-dev#588) that cannot tell two
+    networks apart (litclock-dev#589 item 2). Defaults to the hotspot's own
+    DEFAULT_SSID for any direct caller.
 
     dnsmasq's wildcard on the setup network resolves every hostname to `ip`,
     and nftables redirects 80->8080, so SETUP_HOSTNAME lands on the real
@@ -502,15 +570,28 @@ def setup_instruction_lines(ip: str, is_retry: bool = False) -> list[str]:
       and on an e-ink panel a stray mark is entirely plausible.
     """
     if is_retry:
+        if retry_reason == HOTSPOT_RETRY_CONNECT_FAILED:
+            # litclock-dev#603 — the join failed for a reason that is NOT
+            # the password: a timeout, an unreachable/hidden network, or an
+            # unclassified nmcli error. Password advice here would send the
+            # reader retyping a password that was never the problem; the
+            # likely fixes are radio-physical (band, range). The setup page
+            # shows the specific cause once they're back on it.
+            return [
+                f"1. Rescan the QR code to rejoin {ssid}",
+                "2. Check your WiFi is 2.4GHz and in range of the clock",
+                "3. On the setup page, pick your network and try again",
+                f"4. No page? Open a browser: http://{SETUP_HOSTNAME} or http://{ip}",
+            ]
         return [
-            "1. Rescan the QR code to rejoin LitClock-Setup",
+            f"1. Rescan the QR code to rejoin {ssid}",
             "2. Select your internet WiFi network, type your WiFi password",
             f"3. No page? Open a browser: http://{SETUP_HOSTNAME} or http://{ip}",
         ]
     return [
-        "1. Scan the QR code to join LitClock-Setup",
+        f"1. Scan the QR code to join {ssid}",
         "2. Wait about 20 seconds for a setup page",
-        "3. No page? Join LitClock-Setup in your WiFi settings",
+        f"3. No page? Join {ssid} in your WiFi settings",
         f"4. Then open a browser: http://{SETUP_HOSTNAME} or http://{ip}",
     ]
 
@@ -526,35 +607,50 @@ def create_hotspot_display_image(ssid: str, password: str, ip: str, retry_reason
         ssid: Hotspot network name
         password: Hotspot password
         ip: Hotspot gateway IP (shown as absolute-fallback URL)
-        retry_reason: If set, renders a retry-specific variant. Currently
-            supports HOTSPOT_RETRY_WIFI_PASSWORD ("wifi_password") — used
-            when the user submitted a wrong WiFi password and the setup
-            server has restored the hotspot for another attempt. The user
+        retry_reason: If set, renders a retry-specific variant:
+            HOTSPOT_RETRY_WIFI_PASSWORD ("wifi_password") when the user
+            submitted a wrong WiFi password, HOTSPOT_RETRY_CONNECT_FAILED
+            ("connect_failed") for every other failure class — timeout,
+            network not found, unclassified (litclock-dev#603). The user
             needs distinct signal on the e-ink (not just the browser
             banner) because phones auto-disconnect from the hotspot during
             the failed connection attempt and may not see the banner until
-            they've rescanned the QR.
+            they've rescanned the QR. Both variants share the class-neutral
+            title; the numbered steps differ.
 
     Returns:
         PIL Image ready for display
     """
-    is_retry = retry_reason == HOTSPOT_RETRY_WIFI_PASSWORD
+    is_retry = retry_reason in (HOTSPOT_RETRY_WIFI_PASSWORD, HOTSPOT_RETRY_CONNECT_FAILED)
+
+    # Validate the credentials at the boundary (litclock-dev#589): strip
+    # control chars / newlines that would break the single-line layout. Logs
+    # loudly on any change; the render still proceeds best-effort because a
+    # blank splash on THE setup screen is a worse failure than a cleaned one.
+    ssid = _sanitize_render_text(ssid, "network name")
+    password = _sanitize_render_text(password, "password")
 
     # Create white background
     image = Image.new("1", DISPLAY_SIZE, 255)
     draw = ImageDraw.Draw(image)
 
-    # Load fonts
+    # Load fonts. On failure (missing fonts/ dir) DON'T fall to a bare
+    # load_default(): on Pillow >= 12 that is a 10px bitmap, which collapses the
+    # 36/22/24/18px hierarchy to ~1.4mm cap height — a fully-painted but
+    # unreadable panel with a clean journal (litclock-dev#589 item 3). Pass
+    # size= (Pillow >= 10.1 returns scalable Aileron) and log an ERROR so a
+    # broken fonts/ dir is never silent.
     try:
         title_font = ImageFont.truetype(FONT_PATH_BOLD, 36)
         label_font = ImageFont.truetype(FONT_PATH_BOLD, 22)
         value_font = ImageFont.truetype(FONT_PATH, 24)
-        small_font = ImageFont.truetype(FONT_PATH, 18)
-    except Exception:
-        title_font = ImageFont.load_default()
-        label_font = ImageFont.load_default()
-        value_font = ImageFont.load_default()
-        small_font = ImageFont.load_default()
+        small_font = ImageFont.truetype(FONT_PATH, SETUP_SMALL_FONT_PT)
+    except Exception as e:
+        logging.error("setup splash fonts unavailable (%s); using scaled default — legible but off-brand", e)
+        title_font = ImageFont.load_default(size=36)
+        label_font = ImageFont.load_default(size=22)
+        value_font = ImageFont.load_default(size=24)
+        small_font = ImageFont.load_default(size=SETUP_SMALL_FONT_PT)
 
     # Title — swap to a distinct retry title so the user's eye immediately
     # registers "something changed, read this." E-ink is monochrome so we
@@ -593,7 +689,7 @@ def create_hotspot_display_image(ssid: str, password: str, ip: str, retry_reason
     # WiFi QR code (standard format that phones auto-recognize). Same QR in
     # the retry state — the hotspot credentials are unchanged, only the
     # user-facing instructions differ.
-    wifi_qr_data = f"WIFI:T:WPA;S:{ssid};P:{password};;"
+    wifi_qr_data = f"WIFI:T:WPA;S:{_wifi_qr_escape(ssid)};P:{_wifi_qr_escape(password)};;"
     qr_size = SETUP_QR_SIZE
     qr_image = generate_qr_image(wifi_qr_data)
     qr_image = qr_image.resize((qr_size, qr_size), Image.Resampling.NEAREST)
@@ -607,13 +703,30 @@ def create_hotspot_display_image(ssid: str, password: str, ip: str, retry_reason
     text_x = qr_x + qr_size + 30
     text_y = qr_y + 10
 
+    # Clamp the values to the right-column budget so a long SSID/password can't
+    # clip silently at x=800 with no ellipsis (litclock-dev#589 item 1). The
+    # budget is the panel width minus the value's left edge.
+    value_budget = DISPLAY_SIZE[0] - text_x
+    ssid_line = _clamp_to_width(ssid, value_font, draw, value_budget, "network name")
+    password_line = _clamp_to_width(password, value_font, draw, value_budget, "password")
+
     draw.text((text_x, text_y), SETUP_LABEL_NETWORK, font=label_font, fill=0)
-    draw.text((text_x, text_y + 30), ssid, font=value_font, fill=0)
+    draw.text((text_x, text_y + 30), ssid_line, font=value_font, fill=0)
 
     draw.text((text_x, text_y + 80), SETUP_LABEL_PASSWORD, font=label_font, fill=0)
-    draw.text((text_x, text_y + 110), password, font=value_font, fill=0)
+    draw.text((text_x, text_y + 110), password_line, font=value_font, fill=0)
 
-    lines = setup_instruction_lines(ip, is_retry=is_retry)
+    lines = setup_instruction_lines(ip, ssid=ssid, is_retry=is_retry, retry_reason=retry_reason)
+
+    # Per-line clamp (litclock-dev#626, the litclock-dev#589-review Q4 gap): the credential
+    # block clamps its values, but the STEP lines interpolate the same ssid
+    # (and ip) with no width guard of their own. Clamping each line to the
+    # panel width means an over-long value ellipsizes here the same way it
+    # does in the credential block, instead of clipping at x=800 — and it
+    # keeps `widest` <= panel so the block_x centring below never degrades.
+    lines = [
+        _clamp_to_width(line, small_font, draw, DISPLAY_SIZE[0], f"setup step {i + 1}") for i, line in enumerate(lines)
+    ]
 
     # Stack the lines bottom-up so both 3-line and 4-line layouts sit flush
     # with the bottom edge at a consistent padding.
@@ -758,8 +871,14 @@ def create_handoff_splash_image(settings: dict, qr_url: str) -> Image.Image:
         label_font = ImageFont.truetype(FONT_PATH_BOLD, 22)
         row_font = ImageFont.truetype(FONT_PATH, 22)
         small_font = ImageFont.truetype(FONT_PATH, 18)
-    except Exception:
-        brand_font = heading_font = label_font = row_font = small_font = ImageFont.load_default()
+    except Exception as e:
+        # size= + log, never a silent 10px collapse (litclock-dev#589 item 3).
+        logging.error("handoff splash fonts unavailable (%s); using scaled default", e)
+        brand_font = ImageFont.load_default(size=26)
+        heading_font = ImageFont.load_default(size=40)
+        label_font = ImageFont.load_default(size=22)
+        row_font = ImageFont.load_default(size=22)
+        small_font = ImageFont.load_default(size=18)
 
     # Brand wordmark + hairline rule, top-left.
     draw.text((HANDOFF_LEFT_MARGIN, 28), "LITCLOCK", font=brand_font, fill=0)

--- a/src/setup_server.py
+++ b/src/setup_server.py
@@ -90,6 +90,13 @@ WIFI_PLACEHOLDER_EMPTY_TEXT = "No networks found - tap Refresh"
 # top-two referrer geos, and a Cyrillic name is two bytes per character, so
 # "32 characters" would be a factually wrong instruction in the one place
 # where the user has no keyboard and no way to check.
+#
+# The manual-SSID input also interpolates this as its maxlength
+# (litclock-dev#605 item 12). maxlength counts CHARACTERS (UTF-16 code
+# units), so for multi-byte names the client guard is looser than the
+# byte budget — that's fine: it exists to stop the all-ASCII 99% case
+# before a captive-portal round trip, and the byte check in do_POST is
+# the real gate either way.
 SSID_MAX_BYTES = 32
 # Control characters are rejected outright. An interior newline in a
 # hand-typed SSID forges lines in the persistent journal (journald ships
@@ -223,8 +230,8 @@ def _schedule_self_terminate(delay: float = 0.0) -> None:
     When ``delay == 0``, signals synchronously from the calling thread:
     ``os.kill`` queues SIGTERM in the kernel; the default SIGTERM handler
     terminates the Python interpreter (there is NO graceful handler in
-    setup_server — only ``except KeyboardInterrupt`` around serve_forever at
-    lines 1612-1644). The 1s/2s sleep before this call gives the HTTP
+    setup_server — only ``except KeyboardInterrupt`` around the
+    serve_forever calls in ``main()``). The 1s/2s sleep before this call gives the HTTP
     response time to flush; after termination, the firstboot.sh wrapper
     script polls ``/tmp/litclock-setup-done`` (written by
     ``signal_completion()``) to detect successful handoff.
@@ -356,35 +363,77 @@ def _filter_own_hotspot(networks):
 
 
 def _wifi_network_options():
-    """Generate <option> tags for scanned WiFi networks, with 30s caching."""
+    """Generate <option> tags for scanned WiFi networks, with 30s caching.
+
+    Returns ``(options_html, scan_was_empty)``. The flag is explicit
+    because the page build used to infer emptiness by sniffing the
+    rendered HTML for the placeholder copy (litclock-dev#605 item 11) —
+    a check that breaks silently the day the copy gains an escapable
+    character."""
     global _WIFI_SCAN_CACHE, _WIFI_SCAN_TIME, _WIFI_SCAN_SSIDS
     import time
 
-    now = time.monotonic()
-    if _WIFI_SCAN_CACHE is not None and (now - _WIFI_SCAN_TIME) < _WIFI_SCAN_TTL:
-        return _WIFI_SCAN_CACHE
+    # Take _SCAN_CACHE_LOCK across the whole cache-miss path, exactly like
+    # /scan-wifi does. This is the second scan entry point that shares
+    # _WIFI_SCAN_CACHE/_SSIDS/_TIME, and it was previously unlocked
+    # (litclock-dev#615). Consequences of the gap on a threaded server:
+    #   - two concurrent GET / builds at a cold/expired cache each fired their
+    #     own nmcli rescan on the single hotspot radio — the exact contention
+    #     the lock exists to prevent (an iOS CNA sheet + the real browser is a
+    #     realistic pair within the 30s TTL);
+    #   - interleaving with /scan-wifi could leave _WIFI_SCAN_CACHE from one
+    #     scan and _WIFI_SCAN_SSIDS from another, so wifi_hidden in do_POST is
+    #     computed against evidence that doesn't match the dropdown the user
+    #     saw — which can flip a VISIBLE typed SSID to `hidden yes`, the
+    #     permanent probe-request leak litclock-dev#580's policy is meant to prevent;
+    #   - the cache-hit branch double-read _WIFI_SCAN_CACHE unlocked, so a
+    #     concurrent reset to None could interpolate "None" into the <select>.
+    # A waiter that blocks here through another thread's scan finds the fresh
+    # cache on the recheck and skips its own scan entirely.
+    with _SCAN_CACHE_LOCK:
+        now = time.monotonic()
+        if _WIFI_SCAN_CACHE is not None and (now - _WIFI_SCAN_TIME) < _WIFI_SCAN_TTL:
+            return _WIFI_SCAN_CACHE, False
 
-    try:
-        from wifi_provision import scan_wifi_networks
+        try:
+            from wifi_provision import scan_wifi_networks
 
-        networks = scan_wifi_networks()
-    except Exception:
-        networks = []
+            networks = scan_wifi_networks()
+        except Exception:
+            networks = []
 
-    networks = _filter_own_hotspot(networks)
+        networks = _filter_own_hotspot(networks)
 
-    if not networks:
-        # Don't cache empty results — let the next call retry. Still built via
-        # _build_wifi_options so the manual-entry option survives: a user whose
-        # only network is hidden sees an empty scan every time, and dropping
-        # their one path to type it in would strand them (litclock-dev#554).
-        return _build_wifi_options([], placeholder=WIFI_PLACEHOLDER_EMPTY_TEXT)
+        if not networks:
+            # Don't cache empty results — let the next call retry. Still built via
+            # _build_wifi_options so the manual-entry option survives: a user whose
+            # only network is hidden sees an empty scan every time, and dropping
+            # their one path to type it in would strand them (litclock-dev#554).
+            # _WIFI_SCAN_SSIDS deliberately keeps its previous contents: an empty
+            # rescan never clears the evidence, and the thing it guards against —
+            # writing `hidden yes` into the saved profile — is permanent while
+            # the staleness is transient (see the wifi_hidden decision in
+            # do_POST; litclock-dev#605 item 7, refined to UNION by litclock-dev#615).
+            return _build_wifi_options([], placeholder=WIFI_PLACEHOLDER_EMPTY_TEXT), True
 
-    result = _build_wifi_options(networks)
-    _WIFI_SCAN_CACHE = result
-    _WIFI_SCAN_SSIDS = _scanned_ssids(networks)
-    _WIFI_SCAN_TIME = now
-    return result
+        result = _build_wifi_options(networks)
+        _WIFI_SCAN_CACHE = result
+        # UNION, not replace (litclock-dev#615): accumulate every SSID seen this
+        # provisioning session. Scans flicker — a network that is genuinely
+        # visible can be absent from one scan — and a replace would drop it,
+        # flipping a typed, previously-seen name to a permanent `hidden yes`
+        # probe-request leak. Union can only ever SUPPRESS `hidden yes`, never
+        # add one, so it fails in the no-leak direction. reset_state() clears the
+        # set at the session boundary; SSIDs in radio range are bounded, so the
+        # accumulation cannot grow without limit.
+        _WIFI_SCAN_SSIDS = _WIFI_SCAN_SSIDS | _scanned_ssids(networks)
+        # Stamp AFTER the scan, like /scan-wifi does. `now` was measured before a
+        # scan that can take seconds (rescan + 2s settle + list); stamping it
+        # would make the cache born up to that much closer to expiry — a slow
+        # scan near the TTL could yield an already-expired cache that the next
+        # caller immediately rescans, defeating the serialization (litclock-dev#615).
+        _WIFI_SCAN_TIME = time.monotonic()
+        return result, False
 
 
 # Path serving the CNA bridge on our own host — the target of the Apple
@@ -492,13 +541,30 @@ def _build_setup_html():
         # and doubled braces would leak into the rendered HTML as literal
         # `{{` `}}`. (Earlier copies of this code doubled braces defensively
         # for a .format() call site that no longer exists.)
-        safe_error = html.escape(WIFI_CONNECT_ERROR)
+        # Snapshot the global once (litclock-dev#610 review): the connect
+        # thread writes it, and reading it twice — once for the message,
+        # once for the class — could pair an old message with new-class
+        # advice across a mid-render write.
+        connect_error = WIFI_CONNECT_ERROR
+        safe_error = html.escape(connect_error)
+        # litclock-dev#603 — the advice line must not contradict the honest
+        # cause {safe_error} just gave. Password advice only when the failure
+        # actually WAS the password (the class rides on the WifiFailure
+        # error string); a timeout or not-found gets a neutral retry line,
+        # because "double-check your password" after "the network didn't
+        # answer in time" reads as the page arguing with itself.
+        if getattr(connect_error, "failure_class", None) == "bad_password":
+            advice = (
+                "Double-check your <strong>WiFi password</strong> and try "
+                "again &mdash; not the password shown on the clock&rsquo;s screen. "
+            )
+        else:
+            advice = "Check the message above, then try again. "
         wifi_error_banner = (
             '<div style="background:#fef2f2; border:2px solid #ef4444; border-radius:8px;'
             ' padding:12px 16px; margin-bottom:16px; color:#991b1b;">'
             f"<strong>Couldn&rsquo;t join your WiFi:</strong> {safe_error}<br>"
-            "Double-check your <strong>WiFi password</strong> and try "
-            "again &mdash; not the password shown on the clock&rsquo;s screen. "
+            f"{advice}"
             "If this page doesn&rsquo;t reload, rescan the QR code on the "
             "display &mdash; the clock&rsquo;s own network has restarted.</div>"
         )
@@ -522,7 +588,7 @@ def _build_setup_html():
 
     wifi_section = ""
     if PROVISIONING_MODE:
-        network_options = _wifi_network_options()
+        network_options, scan_was_empty = _wifi_network_options()
         # Source the hotspot SSID from the runtime constant rather than
         # hardcoding "LitClock-Setup" — branded builds set this via the
         # --hotspot-ssid CLI flag, and the disambiguating cue ("Not the
@@ -537,8 +603,11 @@ def _build_setup_html():
         # page is blank and re-collapsed: the hidden-network user has to
         # remember what they typed while a red banner tells them to check their
         # PASSWORD, when the likelier fault on that path is the SSID spelling
-        # (/review, litclock-dev#580).
-        scan_was_empty = WIFI_PLACEHOLDER_EMPTY_TEXT in network_options
+        # (/review, litclock-dev#580). The echo covers JOIN failures only: a value the
+        # server rejected outright (malformed, the clock's own hotspot name,
+        # or a POST that lost the in-flight race) is deliberately never
+        # stored, so those paths re-render blank (litclock-dev#605 item 10 — see the
+        # store site in do_POST).
         manual_value = html.escape(WIFI_LAST_MANUAL_SSID)
         manual_open = " open" if (manual_value or scan_was_empty or WIFI_CONNECT_ERROR) else ""
         manual_summary = html.escape(MANUAL_SSID_TEXT)
@@ -588,7 +657,7 @@ def _build_setup_html():
                     <input type="text" id="wifi-ssid-manual" name="{MANUAL_SSID_FIELD}"
                         placeholder="Network name" autocomplete="off"
                         autocapitalize="none" autocorrect="off" spellcheck="false"
-                        value="{manual_value}" maxlength="32">
+                        value="{manual_value}" maxlength="{SSID_MAX_BYTES}">
                 </details>
 
                 <label>Your WiFi Password</label>
@@ -808,6 +877,12 @@ def _build_setup_html():
                 .then(function(networks) {{
                     if (networks.length === 0) {{
                         resetSsidOptions(select, {placeholder_empty_js});
+                        // Match the server-rendered empty-scan path, which
+                        // force-opens this disclosure: a hidden-network user who
+                        // taps Refresh into an empty scan needs the "type it in"
+                        // field visible, not folded away (litclock-dev#615).
+                        var details = document.getElementById('manual-ssid');
+                        if (details) details.open = true;
                     }} else {{
                         resetSsidOptions(select, {placeholder_js});
                         networks.sort(function(a, b) {{
@@ -1319,9 +1394,19 @@ class SetupHandler(http.server.BaseHTTPRequestHandler):
                 # server-rendered dropdown. Leaving either unfiltered re-exposes
                 # the clock's own hotspot SSID.
                 networks = _filter_own_hotspot(networks)
+                # An empty rescan updates NOTHING — same policy as
+                # _wifi_network_options: no caching of empties (next call
+                # retries), and _WIFI_SCAN_SSIDS keeps the evidence an
+                # earlier scan gathered (litclock-dev#605 item 7 — see the
+                # wifi_hidden decision in do_POST for why stale visibility
+                # evidence beats none).
                 if networks:
                     _WIFI_SCAN_CACHE = _build_wifi_options(networks)
-                    _WIFI_SCAN_SSIDS = _scanned_ssids(networks)
+                    # UNION, not replace — accumulate seen SSIDs so a flickered
+                    # scan can't drop a genuinely-visible name and flip it to a
+                    # permanent `hidden yes` leak (litclock-dev#615; see the
+                    # matching write in _wifi_network_options).
+                    _WIFI_SCAN_SSIDS = _WIFI_SCAN_SSIDS | _scanned_ssids(networks)
                     _WIFI_SCAN_TIME = time.monotonic()
             self.send_json(networks)
 
@@ -1342,7 +1427,7 @@ class SetupHandler(http.server.BaseHTTPRequestHandler):
             self.end_headers()
 
     def do_POST(self):
-        global WIFI_CONNECT_ERROR, WIFI_CONNECT_IN_FLIGHT
+        global WIFI_CONNECT_ERROR, WIFI_CONNECT_IN_FLIGHT, WIFI_LAST_MANUAL_SSID
 
         if self.path != "/setup":
             self.send_response(404)
@@ -1394,13 +1479,6 @@ class SetupHandler(http.server.BaseHTTPRequestHandler):
             # was how that state used to arise. See the JS comment.)
             wifi_ssid = wifi_ssid_manual
             wifi_typed = True
-
-        # Remember a typed name so the retry render can echo it back. Set
-        # before any rejection below, so the page the user lands on after an
-        # error still shows what they typed.
-        if wifi_typed:
-            global WIFI_LAST_MANUAL_SSID
-            WIFI_LAST_MANUAL_SSID = wifi_ssid
 
         if PROVISIONING_MODE and not wifi_ssid:
             error = (
@@ -1458,9 +1536,22 @@ class SetupHandler(http.server.BaseHTTPRequestHandler):
         # cannot see the network — a name typed by hand that IS in the current
         # scan is just a user who typed instead of scrolling, and does not
         # deserve a permanent probe-request leak of their home SSID
-        # (/review, litclock-dev#580). When the scan is empty we have no evidence either
-        # way, and we err toward `hidden`: a needless probe leak is a smaller
-        # harm than a hidden network that cannot be joined at all.
+        # (/review, litclock-dev#580). When the evidence set doesn't hold the name we
+        # err toward `hidden`: a needless probe leak is a smaller harm than
+        # a hidden network that cannot be joined at all. The evidence set is
+        # the UNION of every non-empty scan this provisioning session — each
+        # non-empty scan accumulates into it and an empty rescan leaves it
+        # untouched (litclock-dev#605 item 7, refined to union by litclock-dev#615): a
+        # network seen even once stays "visible" evidence across later scan
+        # flicker, because the `hidden yes` it suppresses would be written into
+        # the saved profile permanently while any staleness is transient.
+        #
+        # This read of _WIFI_SCAN_SSIDS is deliberately OUTSIDE _SCAN_CACHE_LOCK
+        # (litclock-dev#615): it is a single atomic reference-read of an
+        # immutable frozenset that the scan writers only ever rebind wholesale
+        # under the lock, so it always resolves to one complete evidence set.
+        # Do NOT pair it with a second lock-guarded global at this site without
+        # taking the lock — that would reintroduce the torn read litclock-dev#615 closed.
         wifi_hidden = wifi_typed and wifi_ssid.casefold() not in _WIFI_SCAN_SSIDS
 
         # Send success response BEFORE connecting to WiFi. On the Pi Zero 2W,
@@ -1510,6 +1601,18 @@ class SetupHandler(http.server.BaseHTTPRequestHandler):
                     return
                 WIFI_CONNECT_IN_FLIGHT = True
                 WIFI_CONNECT_ERROR = None  # Clear stale error from previous attempt
+                # Remember a typed name so the retry render can echo it back
+                # (litclock-dev#605 review item 10). Stored HERE — after every rejection
+                # (empty/control-chars/over-long, the own-hotspot refusal),
+                # after the PROVISIONING_MODE gate (a normal-mode POST skips
+                # the validations entirely, so nothing it carries may land in
+                # this global), and after winning the in-flight CAS (a POST
+                # that races a live attempt never joins, so its name must not
+                # become the retry echo) — the global only ever holds the
+                # <=32-byte validated SSID of a join actually launched.
+                # Same lock as reset_wifi_globals, the other writer.
+                if wifi_typed:
+                    WIFI_LAST_MANUAL_SSID = wifi_ssid
 
             def _connect_and_teardown():
                 global WIFI_CONNECT_ERROR, WIFI_CONNECT_IN_FLIGHT
@@ -1530,7 +1633,13 @@ class SetupHandler(http.server.BaseHTTPRequestHandler):
                         # reconnect and the user can retry.
                         WIFI_CONNECT_ERROR = error
                         print(f"WiFi connection failed: {error}")
-                        _restore_hotspot(create_hotspot)
+                        # litclock-dev#603 — thread the failure class through
+                        # so the e-ink retry variant matches the actual cause
+                        # (a timeout painted wrong-password guidance before).
+                        _restore_hotspot(
+                            create_hotspot,
+                            failure_class=getattr(error, "failure_class", None),
+                        )
                         return  # Keep server alive for retry
 
                     # WiFi connected — resolve location from IP, then clean up.
@@ -1650,16 +1759,23 @@ class HTTPSServer(socketserver.ThreadingMixIn, socketserver.TCPServer):
         self.socket = context.wrap_socket(self.socket, server_side=True)
 
 
-def _restore_hotspot(create_hotspot_fn):
+def _restore_hotspot(create_hotspot_fn, failure_class=None):
     """Restore the hotspot after a failed WiFi connection attempt.
 
     On single-radio Pi hardware, nmcli tears down the hotspot when attempting
     a station connection. If the connection fails, we must recreate the hotspot
     so the user can reconnect and retry — AND refresh the e-ink display with a
-    distinct "Wrong Password — Retry" variant, because phones auto-disconnect
-    from the hotspot during the failed attempt and may not see the red banner
-    on the setup form until they've rescanned the QR. The e-ink is the only
-    surface the user is looking at during that gap.
+    retry variant, because phones auto-disconnect from the hotspot during the
+    failed attempt and may not see the red banner on the setup form until
+    they've rescanned the QR. The e-ink is the only surface the user is
+    looking at during that gap.
+
+    ``failure_class`` (litclock-dev#603) selects the variant: the
+    wrong-password steps only when the failure actually WAS the password;
+    everything else — timeout, not-found, unknown (None included: with no
+    evidence, telling the user to retype their password sends them fixing
+    the one thing known-least-likely to be broken) — gets the class-neutral
+    connect-failed steps.
     """
     if not HOTSPOT_SSID or not HOTSPOT_PASSWORD:
         print("No hotspot credentials available — cannot restore hotspot")
@@ -1692,13 +1808,20 @@ def _restore_hotspot(create_hotspot_fn):
     # Everything else propagates — a TypeError from a bad signature change
     # should fail loud, not silently degrade the retry UX.
     try:
-        from eink_display import HOTSPOT_RETRY_WIFI_PASSWORD, display_hotspot_info
+        from eink_display import HOTSPOT_RETRY_CONNECT_FAILED, HOTSPOT_RETRY_WIFI_PASSWORD, display_hotspot_info
 
+        # Literal, not `from wifi_provision import WIFI_FAIL_BAD_PASSWORD`:
+        # the retry-flow tests replace wifi_provision in sys.modules with a
+        # bare fake, and a missing-name import here would be swallowed by
+        # the ImportError arm below — silently degrading the variant
+        # selection in exactly the tests meant to pin it. A lockstep test
+        # asserts the literal matches wifi_provision.WIFI_FAIL_BAD_PASSWORD.
+        retry_reason = HOTSPOT_RETRY_WIFI_PASSWORD if failure_class == "bad_password" else HOTSPOT_RETRY_CONNECT_FAILED
         display_hotspot_info(
             HOTSPOT_SSID,
             HOTSPOT_PASSWORD,
             HOTSPOT_GATEWAY_IP,
-            retry_reason=HOTSPOT_RETRY_WIFI_PASSWORD,
+            retry_reason=retry_reason,
         )
         logging.info("E-ink refreshed with retry instructions")
     except (ImportError, OSError, RuntimeError):

--- a/src/wifi_provision.py
+++ b/src/wifi_provision.py
@@ -46,6 +46,49 @@ _NMCLI_SECRET_KEYS = frozenset({"password", "wifi-sec.psk", "802-11-wireless-sec
 # status, so no genuine nmcli failure can collide with it.
 NMCLI_TIMEOUT_RC = 124
 
+# Bounds on the two nmcli calls in scan_wifi_networks(). Both scan entry points
+# (the /scan-wifi handler and the GET / page build) hold _SCAN_CACHE_LOCK across
+# the whole scan to serialize radio access, so an UNBOUNDED nmcli here would let
+# a single wedged NetworkManager (D-Bus stall, brcmfmac hang) hold the lock
+# forever and freeze every setup-page render and rescan (litclock-dev#615). A
+# timeout synthesizes rc=124 and the scan degrades to an empty result the
+# callers already handle. Generous on a Pi Zero 2 W's weak 2.4GHz radio: a busy
+# band can make a rescan genuinely slow, so these only trip on a true wedge.
+SCAN_RESCAN_TIMEOUT = 10
+SCAN_LIST_TIMEOUT = 15
+
+# Failure classes carried on connect_to_wifi's error returns
+# (litclock-dev#603). The retry surfaces — the e-ink retry variant and the
+# web banner's advice line — branch on these instead of re-deriving the
+# cause by sniffing user-facing copy (the antipattern litclock-dev#605 item 11 flags).
+WIFI_FAIL_TIMEOUT = "timeout"
+WIFI_FAIL_BAD_PASSWORD = "bad_password"
+WIFI_FAIL_NOT_FOUND = "not_found"
+WIFI_FAIL_NO_IP = "no_ip"
+WIFI_FAIL_OTHER = "other"
+
+
+class WifiFailure(str):
+    """connect_to_wifi's error copy, carrying its failure class.
+
+    A str subclass so every existing consumer — html.escape at the web
+    banner, equality and substring asserts, journald interpolation — keeps
+    working byte-for-byte unchanged; ``failure_class`` rides along for the
+    retry surfaces (litclock-dev#603). Immutable like its base."""
+
+    __slots__ = ("failure_class",)
+
+    def __new__(cls, message, failure_class):
+        obj = super().__new__(cls, message)
+        obj.failure_class = failure_class
+        return obj
+
+    def __getnewargs__(self):
+        # str's default returns one arg; our __new__ demands two, so without
+        # this, copy.copy / deepcopy / pickle all raise TypeError (/review on
+        # litclock-dev#610 — e.g. a future QueueHandler pickling log args).
+        return (str(self), self.failure_class)
+
 
 def _redact_nmcli(cmd):
     """Replace the token after any secret-bearing nmcli key with ***.
@@ -64,8 +107,12 @@ def _redact_nmcli(cmd):
     return out
 
 
-def _run_nmcli(args, check=True, sudo=False, timeout=None):
+def _run_nmcli(args, check=True, sudo=False, timeout=None, secret_output=False, input_text=None):
     """Run an nmcli command and return the result.
+
+    ``input_text`` feeds the command's stdin (litclock-dev#599: the
+    interactive-editor path carries a PSK via stdin so it never transits
+    argv, where sudo's audit line would persist it to journald).
 
     ``timeout`` (seconds, None = unbounded) exists for the connect path
     (litclock-dev#598): on an exists-but-hidden SSID this NM version can
@@ -73,11 +120,18 @@ def _run_nmcli(args, check=True, sudo=False, timeout=None):
     is already torn down and the user's phone dangles with no feedback.
     On expiry the caller gets a synthetic result (returncode 124, stderr
     "nmcli timed out") instead of an exception, so every existing
-    error-handling path keeps working."""
+    error-handling path keeps working.
+
+    ``secret_output`` marks a command whose STDOUT is itself a secret
+    (``-s -g …psk`` reads — litclock-dev#613). argv redaction does not cover
+    OUTPUT, and the TimeoutExpired branch below otherwise logs the partial
+    pre-kill output at ERROR: a wedged secret read could then land the PSK in
+    persistent journald (litclock-dev#616 review). When set, the partial output is
+    replaced with a byte count."""
     cmd = (["sudo"] if sudo else []) + ["nmcli"] + args
     logging.debug(f"Running: {' '.join(_redact_nmcli(cmd))}")
     try:
-        result = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout, input=input_text)
     except subprocess.TimeoutExpired as exc:
         # Keep whatever nmcli wrote before the kill — it's the only record of
         # what NM was doing (slow DHCP vs hidden 5GHz vs wedged daemon) and
@@ -86,11 +140,27 @@ def _run_nmcli(args, check=True, sudo=False, timeout=None):
         # but don't bet on that across versions — normalize either way.
         parts = [p for p in (exc.stdout, exc.stderr) if p]
         partial = " ".join(p.decode("utf-8", "replace") if isinstance(p, bytes) else p for p in parts).strip()
+        if secret_output and partial:
+            # The output is the secret itself — never journal it (litclock-dev#613/litclock-dev#616).
+            partial = f"<{len(partial)} bytes redacted>"
         logging.error(
             f"nmcli timed out after {timeout}s: {' '.join(_redact_nmcli(cmd))}"
             + (f" — output before kill: {partial}" if partial else "")
         )
-        return subprocess.CompletedProcess(cmd, returncode=NMCLI_TIMEOUT_RC, stdout="", stderr="nmcli timed out")
+        # Redacted argv in the synthetic result: .args embeds the command line,
+        # and the connect argv carries the PSK. No current caller logs it, but
+        # the whole redaction machinery exists because a future debug line
+        # writing an argv persists the password to journald (litclock-dev#580) — make the
+        # sentinel object safe to log by construction.
+        return subprocess.CompletedProcess(
+            _redact_nmcli(cmd), returncode=NMCLI_TIMEOUT_RC, stdout="", stderr="nmcli timed out"
+        )
+    # Same invariant on the common path: subprocess.run stored the RAW argv
+    # in result.args, so without this line the "safe to log" property would
+    # hold for exactly one of the two result shapes — the rare one. Nothing
+    # re-executes or compares .args (verified across src/), so overwriting
+    # it loses nothing.
+    result.args = _redact_nmcli(cmd)
     if check and result.returncode != 0:
         logging.error(f"nmcli failed: {result.stderr.strip()}")
     return result
@@ -100,6 +170,69 @@ def _generate_password(length=8):
     """Generate a random password for the hotspot."""
     chars = string.ascii_letters + string.digits
     return "".join(secrets.choice(chars) for _ in range(length))
+
+
+# Hotspot credential bounds (litclock-dev#626). 802.11-2020 §9.4.2.2: an SSID
+# element is 0-32 octets (zero-length is the wildcard SSID, meaningless for an
+# AP we host). WPA2-PSK passphrases (802.11i Annex H, enforced by both
+# wpa_supplicant and hostapd) are 8-63 printable-ASCII characters.
+#
+# The SSID rule is deliberately TIGHTER than 802.11 (which allows any 32
+# octets): printable ASCII only. This AP is ours, and the name must render
+# faithfully on every surface that shows it — the e-ink splash (Aileron has no
+# CJK/emoji glyphs; a Unicode name paints as tofu boxes while the AP
+# broadcasts the real bytes), the /etc/issue box (bash pads printf fields by
+# BYTES while ${#var} counts characters, so any multibyte name misaligns the
+# border), and WIFI: QR parsers on phones (several trim or re-encode
+# non-ASCII). ASCII is the one alphabet where chars == bytes == terminal
+# columns, which is what makes the four-surfaces-agree guarantee of this
+# validator actually hold (/review on litclock-dev#629: three independent
+# passes converged on this).
+HOTSPOT_SSID_MAX_CHARS = 32
+HOTSPOT_PASSWORD_MIN_CHARS = 8
+HOTSPOT_PASSWORD_MAX_CHARS = 63
+
+
+def _outside_printable_ascii(value):
+    return any(not (0x20 <= ord(ch) <= 0x7E) for ch in value)
+
+
+def validate_hotspot_credentials(ssid, password):
+    """Validate an SSID/password pair BEFORE the AP exists (litclock-dev#626).
+
+    create_hotspot() is the single chokepoint through which the live AP, the
+    e-ink QR, the /etc/issue console banner, and the splash instruction steps
+    all receive their credentials, so rejecting out-of-spec values here is what
+    guarantees those four surfaces can never disagree about what the network
+    is. The renderer's own sanitize/clamp (litclock-dev#589) stays as
+    belt-and-suspenders, but after this check it can no longer be the only
+    guard. Unreachable on the shipped path — first-boot.sh always uses the
+    defaults — so this only ever fires on a hand-typed --ssid/--password.
+
+    Returns None when the pair is valid, else a log-safe error string (never
+    echoes the password; never echoes raw control characters).
+    """
+    if not ssid or not ssid.strip():
+        # All-spaces is as bad as empty: an invisible name on every surface,
+        # and phone QR parsers whitespace-trim the payload, so the phone would
+        # seek a DIFFERENT SSID than the AP broadcasts (/review).
+        return "SSID is empty or blank"
+    if _outside_printable_ascii(ssid):
+        return "SSID must be printable ASCII (0x20-0x7E) so every surface renders the same name"
+    if len(ssid) > HOTSPOT_SSID_MAX_CHARS:
+        return f"SSID is {len(ssid)} characters; 802.11 caps SSIDs at {HOTSPOT_SSID_MAX_CHARS} octets"
+    if not password:
+        # Guard None/empty explicitly — this reads as public API and must
+        # return an error string, never raise, for a future direct caller.
+        return "password is missing"
+    if not (HOTSPOT_PASSWORD_MIN_CHARS <= len(password) <= HOTSPOT_PASSWORD_MAX_CHARS):
+        return (
+            f"password must be {HOTSPOT_PASSWORD_MIN_CHARS}-{HOTSPOT_PASSWORD_MAX_CHARS} "
+            f"characters for WPA2-PSK (got {len(password)})"
+        )
+    if _outside_printable_ascii(password):
+        return "password contains characters outside printable ASCII; WPA2-PSK passphrases are printable ASCII"
+    return None
 
 
 _READY_STATES = {"disconnected", "connected", "connecting"}
@@ -333,6 +466,14 @@ def create_hotspot(ssid=DEFAULT_SSID, password=None):
     if password is None:
         password = _generate_password()
 
+    # Reject out-of-spec credentials before ANY side effect (no teardown, no
+    # captive-portal config, no nmcli) — a rejected pair must leave the system
+    # exactly as it was (litclock-dev#626).
+    error = validate_hotspot_credentials(ssid, password)
+    if error:
+        logging.error(f"Refusing to create hotspot: {error}")
+        return None
+
     logging.info(f"Creating hotspot: {ssid}")
 
     if not ensure_wifi_ready():
@@ -397,8 +538,9 @@ def scan_wifi_networks():
     Returns:
         list of dicts with 'ssid', 'signal', 'security', 'in_use'
     """
-    # Trigger a rescan — sudo for consistency with other nmcli calls from systemd
-    _run_nmcli(["device", "wifi", "rescan"], check=False, sudo=True)
+    # Trigger a rescan — sudo for consistency with other nmcli calls from systemd.
+    # Bounded so a wedged NM can't hold _SCAN_CACHE_LOCK forever (litclock-dev#615).
+    _run_nmcli(["device", "wifi", "rescan"], check=False, sudo=True, timeout=SCAN_RESCAN_TIMEOUT)
     time.sleep(2)
 
     # Get results
@@ -406,6 +548,7 @@ def scan_wifi_networks():
         ["-t", "-f", "IN-USE,SSID,SIGNAL,SECURITY", "device", "wifi", "list"],
         check=False,
         sudo=True,
+        timeout=SCAN_LIST_TIMEOUT,
     )
 
     if result.returncode != 0:
@@ -452,6 +595,276 @@ def scan_wifi_networks():
     return networks
 
 
+def _profile_uuids():
+    """Set of saved NM connection profile UUIDs, or None if unreadable.
+
+    UUIDs, not NAMEs (litclock-dev#609 review, Codex + adversarial converged): NM
+    uniquifies a colliding name ("MyNet 1"), an operator can rename a
+    profile over SSH so its name no longer matches its SSID, and duplicate
+    names collapse in a set — all three defeat name membership. UUIDs are
+    stable, unique per profile, and escape-free in terse output.
+
+    Bounded (~0.1s measured; 10s cap for a wedged daemon) and unprivileged —
+    listing needs no polkit session."""
+    result = _run_nmcli(["-t", "-f", "UUID", "connection", "show"], check=False, timeout=10)
+    if result.returncode != 0:
+        return None
+    return {line.strip() for line in result.stdout.splitlines() if line.strip()}
+
+
+def _created_profile_uuids(pre_uuids):
+    """UUIDs of profiles created since the pre-connect snapshot.
+
+    None when the diff cannot be computed (either listing failed) — callers
+    decide per failure class how loud to be, because "unknown" and "known
+    empty" drive different cleanup decisions."""
+    if pre_uuids is None:
+        return None
+    post = _profile_uuids()
+    if post is None:
+        return None
+    return post - pre_uuids
+
+
+def _delete_created_profiles(created, ssid):
+    """Delete the profile(s) THIS attempt created (litclock-dev#595).
+
+    nmcli's own failure exits (wrong password via WRONG_KEY ~24s, SSID not
+    found) leave the just-created profile saved with ``autoconnect=yes`` and
+    the unverified PSK. On a fielded device that profile autoconnect-loops
+    failed WPA auth whenever the real network drops — and the single radio
+    spends every one of those retries NOT rejoining the good network.
+
+    The UUID set-diff means a profile that pre-existed the attempt — under
+    ANY name — is structurally untouchable here, so a previously-working
+    saved network can never be deleted (the hazard the owner declined to
+    risk in litclock-dev#600). Bounded deletes: an unbounded delete against a wedged
+    NetworkManager would recreate the very hang the connect timeout exists
+    to prevent, on the cleanup path.
+    """
+    ok = True
+    for uuid in sorted(created):
+        cleanup = _run_nmcli(["connection", "delete", "uuid", uuid], check=False, sudo=True, timeout=10)
+        if cleanup.returncode != 0:
+            logging.error(
+                f"Could not delete profile {uuid} created by the failed "
+                f"attempt on '{ssid}' (rc={cleanup.returncode}): it may keep "
+                "autoconnecting with an unverified password "
+                "(litclock-dev#595). See journalctl -u NetworkManager."
+            )
+            ok = False
+    return ok
+
+
+def _unescape_terse(field):
+    """Undo nmcli ``-t`` terse-mode escaping (``\\:`` -> ``:``, ``\\\\`` ->
+    ``\\``). nmcli escapes the field separator and backslash in VALUE fields;
+    an SSID legitimately containing a colon arrives as ``My\\:Net`` and would
+    otherwise never match the target (litclock-dev#616 review F8 — silent snapshot miss
+    on colon SSIDs)."""
+    out = []
+    escaped = False
+    for ch in field:
+        if escaped:
+            out.append(ch)
+            escaped = False
+        elif ch == "\\":
+            escaped = True
+        else:
+            out.append(ch)
+    if escaped:  # trailing lone backslash — keep it literally
+        out.append("\\")
+    return "".join(out)
+
+
+def _snapshot_ssid_psks(ssid):
+    """Map of pre-existing wifi profile UUID -> stored PSK for profiles whose
+    802-11-wireless.ssid equals the connect target (litclock-dev#613).
+
+    Hardware-verified 2026-08-09 (NM 1.42.4): ``nmcli device wifi connect``
+    REUSES a pre-existing profile for the SSID and writes the attempted
+    password into it even when the join fails — a previously-working saved
+    network is left armed (autoconnect=yes) with a password that can never
+    authenticate. The litclock-dev#609 UUID set-diff is structurally blind to this (no
+    profile is *created*), so the failure paths restore from this snapshot
+    instead.
+
+    UUID-keyed for the same reasons as _profile_uuids (rename/uniquify).
+    Shape: ONE UUID,TYPE listing + one unprivileged ssid read per WIFI
+    profile + one sudo secret read per SSID MATCH. (litclock-dev#616 tried to fold the
+    ssid into the listing — `-f UUID,TYPE,802-11-wireless.ssid` — but the
+    list form rejects setting properties with rc=2 on real nmcli 1.42.4,
+    which silently disabled the whole restore; hardware-caught in the litclock-dev#630
+    retest. The litclock-dev#616-F1 N+1 concern was specifically per-profile SUDO SECRET
+    reads; the ssid reads here are unprivileged and wifi-only.)
+
+    The PSK values live in this dict IN MEMORY ONLY. The listing/ssid read is
+    unprivileged; only the secret read is sudo. A listing failure or an
+    unreadable secret drops that profile and logs a WARNING (never the value)
+    — restore then degrades to the pre-#613 no-op, but LOUDLY, because a
+    silent miss leaves the fielded device in exactly the litclock-dev#613 brick state with
+    no journal trace (litclock-dev#616 review F6)."""
+    # The LIST form of `connection show` accepts only profile COLUMNS
+    # (NAME, UUID, TYPE, ...) — setting properties like 802-11-wireless.ssid
+    # are rejected with rc=2 "invalid field". The litclock-dev#616 one-listing shape
+    # (`-f UUID,TYPE,802-11-wireless.ssid`) therefore ALWAYS failed on real
+    # nmcli 1.42.4, silently disabling the whole litclock-dev#613 restore; the unit-test
+    # fake accepted the invalid field (hardware-caught during the litclock-dev#630
+    # retest, 2026-08-10). The ssid must come from a per-profile query.
+    # That reintroduces a per-profile read, but NOT the litclock-dev#616-F1 hazard: F1
+    # was about per-profile SUDO SECRET reads serializing 10s timeouts —
+    # these ssid reads are unprivileged, wifi-type-only, and the secret
+    # reads below remain per-MATCH.
+    listing = _run_nmcli(["-t", "-f", "UUID,TYPE", "connection", "show"], check=False, timeout=10)
+    if listing.returncode != 0:
+        logging.warning(
+            f"Could not list connections to snapshot the saved password for "
+            f"'{ssid}' (rc={listing.returncode}) — a failed attempt that "
+            "overwrites a reused profile will NOT be auto-restored "
+            "(litclock-dev#613)."
+        )
+        return {}
+    snapshot = {}
+    for line in listing.stdout.splitlines():
+        parts = line.split(":", 1)
+        if len(parts) < 2:
+            continue
+        uuid, ctype = parts
+        if ctype != "802-11-wireless":
+            continue
+        ssid_q = _run_nmcli(
+            ["-t", "-g", "802-11-wireless.ssid", "connection", "show", "uuid", uuid],
+            check=False,
+            timeout=10,
+        )
+        if ssid_q.returncode != 0:
+            logging.warning(
+                f"Could not read the ssid of wifi profile {uuid} while "
+                f"snapshotting for '{ssid}' (rc={ssid_q.returncode}) — that "
+                "profile will NOT be auto-restored (litclock-dev#613)."
+            )
+            continue
+        if _unescape_terse(ssid_q.stdout.rstrip("\n")) != ssid:
+            continue
+        psk_q = _run_nmcli(
+            ["-s", "-g", "802-11-wireless-security.psk", "connection", "show", "uuid", uuid],
+            check=False,
+            sudo=True,
+            timeout=10,
+            secret_output=True,
+        )
+        if psk_q.returncode != 0:
+            logging.warning(
+                f"Could not read the saved password on profile {uuid} ('{ssid}') "
+                f"to snapshot it (rc={psk_q.returncode}) — a failed attempt that "
+                "overwrites it will NOT be auto-restored (litclock-dev#613)."
+            )
+            continue
+        # ``-g`` output is terse-ESCAPED even for a single field — verified on
+        # NM 1.42.4: a stored ``pa:ss\word`` reads back as ``pa\:ss\\word``
+        # (litclock-dev#599 review F1). Un-escape so every comparison and the
+        # editor replay below operate on the RAW value; without this, a PSK
+        # containing ``:`` or ``\`` silently defeats the whole litclock-dev#613 restore.
+        snapshot[uuid] = _unescape_terse(psk_q.stdout.rstrip("\n"))
+    return snapshot
+
+
+def _restore_ssid_psks(snapshot, ssid, attempted):
+    """Restore each snapshotted profile's PSK when the failed attempt is what
+    overwrote it (litclock-dev#613). Called only on the paths where nmcli
+    reported the connect itself failed — NOT on the rc=0 "connected but no
+    IP" path, where association proves the submitted password was correct and
+    NM's stored value is the right final state.
+
+    Restore condition is ``current == attempted and attempted != good``, not
+    merely ``current != good`` (litclock-dev#616 review, Codex): only undo the exact write
+    THIS attempt made. A value that is neither the good snapshot nor this
+    attempt's password was changed by something else (SSH, a concurrent NM
+    edit) and must not be clobbered; an open network (good == attempted == "")
+    is left alone. Per profile: re-read the current PSK (bounded, sudo —
+    secrets read needs root), then modify only when the condition holds. A
+    failed restore is logged loudly (the profile is left unable to rejoin);
+    the secret never reaches logs OR argv — the write rides the editor's
+    stdin (litclock-dev#599) and the reads use secret_output."""
+    if not snapshot:
+        return
+    for uuid, good in snapshot.items():
+        if attempted == good:
+            continue  # nothing this attempt could have corrupted (e.g. open network)
+        current = _run_nmcli(
+            ["-s", "-g", "802-11-wireless-security.psk", "connection", "show", "uuid", uuid],
+            check=False,
+            sudo=True,
+            timeout=10,
+            secret_output=True,
+        )
+        # Skip unless the stored PSK is exactly what this attempt wrote: an
+        # unreadable profile (deleted meanwhile), an unchanged one, or one a
+        # third party changed are all left untouched. The read is un-escaped
+        # (-g terse-escapes ``:`` and ``\`` — see _snapshot_ssid_psks) so the
+        # comparison is raw-vs-raw.
+        if current.returncode != 0 or _unescape_terse(current.stdout.rstrip("\n")) != attempted:
+            continue
+        # The good PSK goes back via `connection edit` with the commands fed
+        # on STDIN — never `connection modify … wifi-sec.psk <value>`, whose
+        # argv sudo audits to persistent journald; that leaked the RESTORED
+        # (working!) password, the worst credential to leak (litclock-dev#599,
+        # widened by litclock-dev#616). The editor's `set` takes the rest of the line
+        # LITERALLY (verified on NM 1.42.4: colons and backslashes round-trip
+        # unmodified) — but it cannot carry a value with control characters
+        # (each newline would execute as another editor command under sudo)
+        # or leading/trailing whitespace (the editor strips it). No real WPA
+        # passphrase contains either; a snapshot value that does is corrupt,
+        # so refuse loudly rather than write a mangled third value.
+        if good and (any(ord(ch) < 0x20 or ch == "\x7f" for ch in good) or good != good.strip()):
+            logging.error(
+                f"Snapshot password for profile {uuid} ('{ssid}') contains "
+                "characters the profile editor cannot carry safely — restore "
+                "skipped; re-provision this network to fix it (litclock-dev#599)."
+            )
+            continue
+        # An empty good value (open-network profile that somehow got a psk
+        # written) clears the property instead of `set` with no value, which
+        # would drop the editor into an interactive prompt and hang until
+        # the timeout.
+        if good:
+            commands = f"set 802-11-wireless-security.psk {good}\nsave persistent\nquit\n"
+        else:
+            commands = "remove 802-11-wireless-security.psk\nsave persistent\nquit\n"
+        fix = _run_nmcli(
+            ["connection", "edit", "uuid", uuid],
+            check=False,
+            sudo=True,
+            timeout=15,
+            input_text=commands,
+            secret_output=True,
+        )
+        # The editor's exit code is a weak signal (it exits 0 after `quit`
+        # even when `save` printed an error), so the authority on success is
+        # a read-back: the stored PSK must now equal the snapshot.
+        verify = _run_nmcli(
+            ["-s", "-g", "802-11-wireless-security.psk", "connection", "show", "uuid", uuid],
+            check=False,
+            sudo=True,
+            timeout=10,
+            secret_output=True,
+        )
+        restored = verify.returncode == 0 and _unescape_terse(verify.stdout.rstrip("\n")) == good
+        if restored:
+            logging.info(
+                f"Restored the saved password on profile {uuid} ('{ssid}') — the "
+                "failed attempt had overwritten it (litclock-dev#613)."
+            )
+        else:
+            logging.error(
+                f"Could not restore the saved password on profile {uuid} "
+                f"('{ssid}', edit rc={fix.returncode}, verified=False): the "
+                "profile is left with the failed attempt's password and cannot "
+                "rejoin until re-provisioned (litclock-dev#613). "
+                "See journalctl -u NetworkManager."
+            )
+
+
 def connect_to_wifi(ssid, password, hidden=False, connect_timeout=30):
     """
     Connect to a WiFi network.
@@ -468,26 +881,67 @@ def connect_to_wifi(ssid, password, hidden=False, connect_timeout=30):
         connect_timeout: seconds before the nmcli connect is abandoned and
             the half-created profile deleted (litclock-dev#598). None =
             unbounded — the CLI's manual/SSH path passes it via --timeout 0,
-            where "return the hotspot to the user" doesn't apply.
+            where "return the hotspot to the user" doesn't apply and NO
+            profile cleanup runs on any failure path (litclock-dev#595
+            keeps the setup-flow semantics off the recovery path).
 
     Returns:
         (success: bool, error_message: str or None)
     """
     logging.info(f"Connecting to WiFi: {ssid}" + (" (hidden)" if hidden else ""))
 
-    # Use nmcli to connect — sudo needed when run from systemd (no polkit session)
+    # A control character in the password would be consumed as extra --ask
+    # prompt lines below (and can never be part of a real WPA passphrase —
+    # 802.11 Annex H is printable ASCII); reject it before ANY nmcli
+    # activity with the honest failure class (litclock-dev#599).
+    if password and any(ord(ch) < 0x20 or ch == "\x7f" for ch in password):
+        return False, WifiFailure(
+            "WiFi passwords can't contain line breaks or control characters — re-type the password and try again.",
+            WIFI_FAIL_BAD_PASSWORD,
+        )
+
+    # litclock-dev#595 snapshot-and-diff: capture the profile UUID set BEFORE
+    # the connect so every failure path below can tell what THIS attempt
+    # created. UUIDs, not names — see _profile_uuids.
+    pre_uuids = _profile_uuids()
+
+    # litclock-dev#613: also snapshot the stored PSK of any PRE-EXISTING
+    # profile for this SSID — nmcli reuses such a profile and persists the
+    # attempted password into it even on failure (hardware-verified). Gated
+    # like the cleanup below: the manual --timeout 0 SSH-recovery path must
+    # never touch profiles (litclock-dev#600 decision d), so it skips the snapshot too.
+    pre_psks = _snapshot_ssid_psks(ssid) if connect_timeout is not None else {}
+
+    # Use nmcli to connect — sudo needed when run from systemd (no polkit
+    # session). The PSK travels via `--ask` + stdin, NEVER as a `password
+    # <value>` argv token: sudo's command-audit line writes the full argv to
+    # persistent journald, so the old form logged every attempted password —
+    # and after litclock-dev#616, restored good ones — to disk on every provisioning
+    # (litclock-dev#599, hardware-verified on the QA Pi including a real home
+    # PSK). NOT --passwd-file: that option does not exist on nmcli 1.42.4
+    # (verified on-device — "Option '--passwd-file' is unknown"; it is a
+    # `connection up` sub-argument only). With --ask, nmcli prompts for
+    # whatever secret NM requests (psk for WPA, wep-key for WEP — no
+    # secret-type hardcoding) and reads it from stdin when stdin is a pipe;
+    # verified live on NM 1.42.4: the prompt consumed a piped password and
+    # activation proceeded. On a wrong password NM re-asks, stdin is at EOF,
+    # and nmcli fails with the same "Secrets were required" error string the
+    # classification below already handles. An empty password (open network —
+    # the setup form says "leave blank") omits --ask entirely. Control
+    # characters in the password were already rejected at the top of this
+    # function.
     args = [
         "device",
         "wifi",
         "connect",
         ssid,
-        "password",
-        password,
         "ifname",
         "wlan0",
     ]
     if hidden:
         args += ["hidden", "yes"]
+    if password:
+        args = ["--ask"] + args
 
     # litclock-dev#598: bound the connect. Hardware-measured: an
     # exists-but-hidden SSID blocks ~107s inside NM activation before
@@ -496,7 +950,13 @@ def connect_to_wifi(ssid, password, hidden=False, connect_timeout=30):
     # is generous for a genuine slow hidden association (the successful
     # hidden join measured ~3s) and returns the hotspot to the user while
     # they still have context.
-    result = _run_nmcli(args, check=False, sudo=True, timeout=connect_timeout)
+    result = _run_nmcli(
+        args,
+        check=False,
+        sudo=True,
+        timeout=connect_timeout,
+        input_text=(password + "\n") if password else None,
+    )
 
     if result.returncode != 0:
         error = result.stderr.strip()
@@ -520,31 +980,86 @@ def connect_to_wifi(ssid, password, hidden=False, connect_timeout=30):
                     _clear_wifi_watchdog_counter()
                     return True, None
                 time.sleep(1)
-            # No rescue: THIS delete is what actually aborts the in-flight
-            # activation and drops the half-created profile; without it the
-            # profile lingers with autoconnect=yes and a possibly-wrong
-            # password (the litclock-dev#595 failure class, made worse by a
-            # kill). Explicit "id" selector — bare `delete <ssid>` makes
-            # nmcli spec-guess, and an SSID named "id"/"uuid"/"path" would
-            # break the cleanup. The result is checked because a silent
-            # delete failure leaves BOTH the armed profile and a live
-            # activation racing the hotspot restore for the single radio.
-            cleanup = _run_nmcli(["connection", "delete", "id", ssid], check=False, sudo=True, timeout=10)
-            if cleanup.returncode != 0:
+            # No rescue: abort the in-flight activation FIRST, independent of
+            # profile identity (litclock-dev#609 review — the sharpest hole): nmcli was
+            # only a D-Bus client, NM keeps trying, and litclock-dev#600's delete-as-abort
+            # only worked when the activated profile happened to be NAMED
+            # exactly the SSID (nmcli reuses profiles by SSID match, and an
+            # operator can rename one over SSH). `device disconnect` stops
+            # whatever wlan0 is activating so the hotspot restore isn't
+            # racing it for the single radio. create_hotspot recovers the
+            # manual-disconnected state this leaves (ensure_wifi_ready
+            # accepts `disconnected`; the hotspot activation is explicit).
+            abort = _run_nmcli(["device", "disconnect", "wlan0"], check=False, sudo=True, timeout=10)
+            if abort.returncode != 0:
                 logging.error(
-                    f"Could not delete half-created profile '{ssid}' "
-                    f"(rc={cleanup.returncode}): it may keep autoconnecting "
-                    "with an unverified password (litclock-dev#595) and its "
-                    "activation may still be racing the hotspot restore. "
+                    f"Could not disconnect wlan0 after the bound expired on "
+                    f"'{ssid}' (rc={abort.returncode}): the activation may "
+                    "still be racing the hotspot restore. "
                     "See journalctl -u NetworkManager."
                 )
-            return False, (
+            # Then drop what this attempt created (the armed-profile half).
+            created = _created_profile_uuids(pre_uuids)
+            if created is None:
+                # Listing broken — fall back to litclock-dev#600's shipped name-targeted
+                # delete. On THIS path an armed leftover is near-certain (the
+                # attempt got far enough to activate) and the abort above
+                # already handled the racing-activation half; the residual
+                # risk (a same-named pre-existing profile deleted while
+                # listing is broken but delete works) is the documented
+                # double-fault tradeoff. Explicit "id" selector — bare
+                # `delete <ssid>` makes nmcli spec-guess.
+                cleanup = _run_nmcli(["connection", "delete", "id", ssid], check=False, sudo=True, timeout=10)
+                if cleanup.returncode != 0:
+                    logging.error(
+                        f"Could not delete half-created profile '{ssid}' "
+                        f"(rc={cleanup.returncode}): it may keep autoconnecting "
+                        "with an unverified password (litclock-dev#595). "
+                        "See journalctl -u NetworkManager."
+                    )
+            else:
+                _delete_created_profiles(created, ssid)
+            # A reused pre-existing profile survives the delete above by
+            # design — un-write the failed password from it (litclock-dev#613).
+            _restore_ssid_psks(pre_psks, ssid, password)
+            return False, WifiFailure(
                 f"Couldn't reach '{ssid}' — the network didn't answer in time. "
-                "Check that it's a 2.4GHz network and in range, then try again."
+                "Check that it's a 2.4GHz network and in range, then try again.",
+                WIFI_FAIL_TIMEOUT,
             )
+        # nmcli exited on its own — no activation left running, but the
+        # profile this attempt created survives with autoconnect=yes and the
+        # unverified password (litclock-dev#595 — hardware repro: a wrong PSK
+        # fails via WRONG_KEY in ~24s and the armed profile remains; on a
+        # fielded device it then autoconnect-loops failed auth whenever the
+        # real network drops). Clean up what this attempt created before
+        # returning. The manual --timeout 0 path opts out entirely (litclock-dev#600
+        # decision d — SSH-recovery semantics must never delete profiles).
+        # When the UUID diff is unavailable, SKIP the cleanup rather than
+        # guess by name (litclock-dev#609 Codex): unlike the timeout branch there is no
+        # activation to abort here, so a name-targeted delete has no upside
+        # to weigh against deleting a good pre-existing profile.
+        if connect_timeout is not None:
+            created = _created_profile_uuids(pre_uuids)
+            if created is None:
+                logging.warning(
+                    f"Could not determine whether the failed attempt on "
+                    f"'{ssid}' left a profile behind (connection listing "
+                    "unavailable) — leaving profiles untouched "
+                    "(litclock-dev#595)."
+                )
+            else:
+                _delete_created_profiles(created, ssid)
+            # The wrong-password path on a REUSED profile creates nothing —
+            # it corrupts the pre-existing profile's stored PSK instead
+            # (hardware: 6s rc=4 "Secrets were required", stored PSK ==
+            # the failed attempt's). Restore what this attempt overwrote
+            # (litclock-dev#613).
+            _restore_ssid_psks(pre_psks, ssid, password)
+
         # Parse common error messages for user-friendly messages
         if "Secrets were required" in error or "password" in error.lower():
-            return False, "Incorrect WiFi password"
+            return False, WifiFailure("Incorrect WiFi password", WIFI_FAIL_BAD_PASSWORD)
         if "No network with SSID" in error:
             # litclock-dev#598 (hardware-established): for a TYPED name this
             # is usually NOT a typo — a hidden 5GHz-only network is invisible
@@ -552,13 +1067,14 @@ def connect_to_wifi(ssid, password, hidden=False, connect_timeout=30):
             # hidden 2.4GHz one can too until it enters the scan cache. Lead
             # with the likely causes; keep the spelling hint last.
             if hidden:
-                return False, (
+                return False, WifiFailure(
                     f"Couldn't find '{ssid}'. If it's a hidden network, make sure "
                     "it's 2.4GHz and in range, then try again. Also double-check "
-                    "the exact spelling — network names are case-sensitive."
+                    "the exact spelling — network names are case-sensitive.",
+                    WIFI_FAIL_NOT_FOUND,
                 )
-            return False, f"Network '{ssid}' not found"
-        return False, f"Connection failed: {error}"
+            return False, WifiFailure(f"Network '{ssid}' not found", WIFI_FAIL_NOT_FOUND)
+        return False, WifiFailure(f"Connection failed: {error}", WIFI_FAIL_OTHER)
 
     # Verify connection - wait for IP address
     for _ in range(15):
@@ -569,7 +1085,7 @@ def connect_to_wifi(ssid, password, hidden=False, connect_timeout=30):
             return True, None
         time.sleep(1)
 
-    return False, "Connected but could not obtain IP address"
+    return False, WifiFailure("Connected but could not obtain IP address", WIFI_FAIL_NO_IP)
 
 
 def _clear_wifi_watchdog_counter():

--- a/systemd/litclock-update.timer
+++ b/systemd/litclock-update.timer
@@ -12,8 +12,10 @@ OnCalendar=Sun 03:00
 Persistent=true
 # 7-day randomization spreads load across the fleet so a bad release
 # can only reach devices at a rate proportional to time since cut.
-# Maintainer has up to 7 days to mark a bad release `prerelease: true`
-# before most devices have pulled it.
+# The reaction lever inside that window is the TAG, not the Release:
+# devices resolve the /tags API (github_api.sh, litclock-dev#247), so marking a
+# Release `prerelease` hides nothing — delete the bad tag or push a
+# higher one (litclock-dev#605).
 RandomizedDelaySec=7d
 
 [Install]

--- a/tests/test_eink_display.py
+++ b/tests/test_eink_display.py
@@ -1,9 +1,10 @@
 """Tests for eink_display module — QR code generation (no hardware needed)."""
 
+import logging
 import sys
 
 import pytest
-from PIL import Image
+from PIL import Image, ImageDraw, ImageFont
 
 # eink_display imports qrcode at module level and calls setup_logging(),
 # which is fine. But waveshare_epd is only imported inside get_display().
@@ -159,7 +160,7 @@ class TestSetupSplashCopy:
         would block a wording decision without measuring anything real. The
         510px budget is the actual constraint and both clear it.
         """
-        from PIL import Image, ImageDraw, ImageFont
+        from PIL import Image
 
         draw = ImageDraw.Draw(Image.new("1", eink_display.DISPLAY_SIZE, 255))
         font = ImageFont.truetype(eink_display.FONT_PATH_BOLD, 22)
@@ -168,31 +169,43 @@ class TestSetupSplashCopy:
             width = draw.textbbox((0, 0), label, font=font)[2]
             assert width < budget, f"{label!r} is {width}px, over the {budget}px budget"
 
+    # Every instruction-block shape the renderer can produce. A variant
+    # missing here is invisible to every guard below — the litclock-dev#603
+    # connect_failed variant shipped with exactly that gap (/review).
+    ALL_VARIANTS = [
+        (False, None),
+        (True, None),  # pre-#603 call shape — renders the password copy
+        (True, "wifi_password"),
+        (True, "connect_failed"),
+    ]
+
     def test_instruction_lines_fit_the_panel(self):
         """The block is centred on its widest line and the lines are
         left-aligned within it, so the whole 800px is the budget."""
-        from PIL import Image, ImageDraw, ImageFont
+        from PIL import Image
 
         draw = ImageDraw.Draw(Image.new("1", eink_display.DISPLAY_SIZE, 255))
         font = ImageFont.truetype(eink_display.FONT_PATH, 18)
-        for is_retry in (False, True):
-            for line in eink_display.setup_instruction_lines("192.168.100.100", is_retry=is_retry):
+        for is_retry, retry_reason in self.ALL_VARIANTS:
+            for line in eink_display.setup_instruction_lines(
+                "192.168.100.100", is_retry=is_retry, retry_reason=retry_reason
+            ):
                 width = draw.textbbox((0, 0), line, font=font)[2]
                 assert width < eink_display.DISPLAY_SIZE[0], f"{line!r} is {width}px"
 
-    @pytest.mark.parametrize("is_retry", [False, True])
-    def test_instruction_lines_do_not_say_hotspot(self, is_retry):
-        lines = eink_display.setup_instruction_lines("10.42.0.1", is_retry=is_retry)
+    @pytest.mark.parametrize(("is_retry", "retry_reason"), ALL_VARIANTS)
+    def test_instruction_lines_do_not_say_hotspot(self, is_retry, retry_reason):
+        lines = eink_display.setup_instruction_lines("10.42.0.1", is_retry=is_retry, retry_reason=retry_reason)
         assert not any("hotspot" in line.lower() for line in lines), lines
 
-    @pytest.mark.parametrize("is_retry", [False, True])
-    def test_no_punctuation_a_reader_could_mistake_for_the_address(self, is_retry):
+    @pytest.mark.parametrize(("is_retry", "retry_reason"), ALL_VARIANTS)
+    def test_no_punctuation_a_reader_could_mistake_for_the_address(self, is_retry, retry_reason):
         """The fallback used to read "litclock.setup  |  10.42.0.1". A pipe
         between two URL-shaped strings does not say "or" to someone who has
         never seen one used that way — it looks like part of what to type,
         and they type it. Alternatives are separated by the word.
         """
-        lines = eink_display.setup_instruction_lines("10.42.0.1", is_retry=is_retry)
+        lines = eink_display.setup_instruction_lines("10.42.0.1", is_retry=is_retry, retry_reason=retry_reason)
         assert not any("|" in line for line in lines), lines
         fallback = [ln for ln in lines if eink_display.SETUP_HOSTNAME in ln]
         assert fallback, lines
@@ -256,19 +269,29 @@ class TestSetupSplashCopy:
         above is satisfied by a colliding line just as well as a clear one.
 
         Assert the real clearance for every line count the renderer actually
-        produces. Today that is 3 (retry) and 4 (first run), which clear by
-        34px and 6px. A fifth line would put the block top at y=320 against
-        framing ink ending at 342, so adding one makes THIS test fail rather
-        than silently overlapping on a panel nobody looks at until a
-        stranger is holding the device.
+        produces. Today that is 3 (password retry), 4 (first run), and 4
+        (connect-failed retry, litclock-dev#603). A fifth line would put the
+        block top at y=320 against framing ink ending at 342, so adding one
+        makes THIS test fail rather than silently overlapping on a panel
+        nobody looks at until a stranger is holding the device. (The retry
+        variants skip the framing line entirely, so for them the binding
+        constraint is the QR block above — covered by the quiet-zone guard.)
         """
-        from PIL import Image, ImageDraw, ImageFont
+        from PIL import Image
 
         draw = ImageDraw.Draw(Image.new("1", eink_display.DISPLAY_SIZE, 255))
         font = ImageFont.truetype(eink_display.FONT_PATH, 18)
         framing_bottom = draw.textbbox((0, eink_display.SETUP_FRAMING_Y), eink_display.SETUP_FRAMING_LINE, font=font)[3]
 
-        produced = {len(eink_display.setup_instruction_lines("10.42.0.1", is_retry=r)) for r in (False, True)}
+        produced = {
+            len(eink_display.setup_instruction_lines("10.42.0.1", is_retry=r, retry_reason=reason))
+            for r, reason in (
+                (False, None),
+                (True, None),
+                (True, eink_display.HOTSPOT_RETRY_WIFI_PASSWORD),
+                (True, eink_display.HOTSPOT_RETRY_CONNECT_FAILED),
+            )
+        }
         for count in sorted(produced):
             top = eink_display.instruction_block_top(count)
             assert framing_bottom < top, (
@@ -326,7 +349,11 @@ class TestSetupSplashCopy:
         qx, qy, qs = eink_display.SETUP_QR_X, eink_display.SETUP_QR_Y, eink_display.SETUP_QR_SIZE
         margin = eink_display.SETUP_QR_QUIET_ZONE_PX
         for ssid, password in (("", ""), ("LitClock-Setup", "clockwis"), ("LitClock-Setup", "clockwise42")):
-            for retry_reason in (None, eink_display.HOTSPOT_RETRY_WIFI_PASSWORD):
+            for retry_reason in (
+                None,
+                eink_display.HOTSPOT_RETRY_WIFI_PASSWORD,
+                eink_display.HOTSPOT_RETRY_CONNECT_FAILED,
+            ):
                 img = eink_display.create_hotspot_display_image(
                     ssid or "x", password or "y", "10.42.0.1", retry_reason=retry_reason
                 )
@@ -465,7 +492,6 @@ class TestSetupSplashCopy:
         the helper directly, so create_hotspot_display_image could regress to
         drawing a literal "Hotspot Network:" — or omit the labels entirely —
         and the whole file would stay green. Capture what reaches the canvas."""
-        from PIL import ImageDraw
 
         drawn = []
         original = ImageDraw.ImageDraw.text
@@ -487,7 +513,6 @@ class TestSetupSplashCopy:
         assert not any("hotspot" in str(t).lower() for t in drawn), drawn
 
     def test_retry_splash_also_draws_only_the_new_copy(self):
-        from PIL import ImageDraw
 
         drawn = []
         original = ImageDraw.ImageDraw.text
@@ -512,3 +537,206 @@ class TestSetupSplashCopy:
         to match in their WiFi list. It was the only variant naming nothing."""
         lines = eink_display.setup_instruction_lines("10.42.0.1", is_retry=True)
         assert any("LitClock-Setup" in line for line in lines), lines
+
+
+class TestSetupStepLineClamp:
+    """litclock-dev#626 (the litclock-dev#589-review Q4 gap): the instruction STEP lines
+    interpolate the ssid/ip but had no per-line width guard — a long value
+    clipped at x=800 and could show a DIFFERENT truncation than the credential
+    block, the exact two-networks-don't-match confusion litclock-dev#589 exists to
+    prevent. Each line now goes through _clamp_to_width."""
+
+    def _steps_image(self, caplog, ssid):
+        with caplog.at_level(logging.WARNING):
+            img = eink_display.create_hotspot_display_image(ssid, "Ab3xYz9q", "10.42.0.1")
+        assert img.size == eink_display.DISPLAY_SIZE
+        return [r.message for r in caplog.records if "setup step" in r.message]
+
+    def test_default_ssid_steps_are_never_clamped(self, caplog):
+        # The shipped path must not ellipsize a single step line.
+        assert self._steps_image(caplog, "LitClock-Setup") == []
+
+    def test_realistic_max_length_ssid_steps_are_never_clamped(self, caplog):
+        # A realistic mixed-case SSID at the 32-char validation cap fits every
+        # step line whole at 18pt — measured, not assumed.
+        assert self._steps_image(caplog, "MyVeryLongHomeNetworkName2026-XY") == []
+
+    def test_pathological_max_width_ssid_is_clamped_honestly(self, caplog):
+        # 32 W's pass the boundary but are the widest glyph run the validator
+        # admits — measured 880px > 800 for step 3 at 18pt, so the clamp MUST
+        # fire with a warning (honest ellipsis), never a silent clip at x=800.
+        # Unconditional assert: a hedged `if messages:` version could never
+        # fail if a regression stopped the warning entirely (/review, two
+        # passes converged on the vacuity).
+        messages = self._steps_image(caplog, "W" * 32)
+        assert messages, "expected the W*32 ssid to clamp at least one step line with a warning"
+        assert all("truncated" in m for m in messages)
+
+    def test_over_long_ssid_step_lines_are_clamped_and_logged(self, caplog):
+        # Belt-and-suspenders beyond the boundary: a direct renderer caller
+        # with an absurd ssid gets an ellipsized line and a WARNING naming the
+        # step, not a silent clip at the panel edge.
+        messages = self._steps_image(caplog, "A" * 120)
+        assert messages, "expected at least one 'setup step N' truncation warning"
+        assert any("truncated" in m for m in messages)
+
+    def test_clamped_steps_still_fit_the_panel(self):
+        # Every drawn line must measure within the panel for an absurd ssid.
+        # SETUP_SMALL_FONT_PT, not a hardcoded 18: the measurement must track
+        # the size production actually draws at (/review).
+        draw = ImageDraw.Draw(Image.new("1", eink_display.DISPLAY_SIZE, 255))
+        font = ImageFont.truetype(eink_display.FONT_PATH, eink_display.SETUP_SMALL_FONT_PT)
+        lines = eink_display.setup_instruction_lines("10.42.0.1", ssid="A" * 120)
+        clamped = [
+            eink_display._clamp_to_width(ln, font, draw, eink_display.DISPLAY_SIZE[0], f"setup step {i + 1}")
+            for i, ln in enumerate(lines)
+        ]
+        for ln in clamped:
+            assert draw.textlength(ln, font=font) <= eink_display.DISPLAY_SIZE[0]
+
+
+class TestSetupSplashHardening:
+    """litclock-dev#589. The hotspot splash renderer treated its ssid/password
+    args as constants. Production is protected only by the 14-char DEFAULT_SSID
+    and the 8-char generated password; wifi_provision honours --ssid and the
+    generator could change, and this is the ONE screen where a rendering
+    failure means the device cannot be set up at all. Each guard below degrades
+    gracefully AND logs — never a silent clip, silent 10px collapse, or a
+    wrong-network QR."""
+
+    # Derived from the renderer's own geometry, NOT the literal 290, so the
+    # budget tracks the QR position if it ever moves (/review).
+    VALUE_LEFT_EDGE = eink_display.SETUP_QR_X + eink_display.SETUP_QR_SIZE + 30
+    VALUE_BUDGET = eink_display.DISPLAY_SIZE[0] - VALUE_LEFT_EDGE
+
+    def test_wifi_qr_payload_escapes_reserved_chars(self):
+        # \ ; , : " are structural in the WIFI: format; unescaped they encode a
+        # different (wrong) network onto the scanning phone.
+        assert eink_display._wifi_qr_escape('a;b:c,d"e\\f') == 'a\\;b\\:c\\,d\\"e\\\\f'
+        assert eink_display._wifi_qr_escape("PlainNet") == "PlainNet"
+
+    def test_control_chars_are_stripped_and_logged(self, caplog):
+        # Newline (breaks single-line layout), CR, BEL, NUL, TAB, DEL.
+        with caplog.at_level(logging.WARNING):
+            out = eink_display._sanitize_render_text("Home\r\nWiFi\x07\x00\t\x7f", "ssid")
+        assert out == "HomeWiFi"
+        assert any("control characters" in r.message for r in caplog.records)
+
+    def test_sanitize_drops_c1_and_unicode_separators_keeps_printable(self):
+        # /review: str.isprintable() also drops C1 (U+0085 NEL), the line/para
+        # separators U+2028/U+2029, and NBSP — which a bare 32<=ord<127 range
+        # missed — while keeping accented letters and emoji.
+        assert eink_display._sanitize_render_text("a\x85b\u2028c\u2029d\xa0e", "ssid") == "abcde"
+        assert eink_display._sanitize_render_text("Café-WiFi", "ssid") == "Café-WiFi"
+
+    def test_sanitize_keeps_spaces_and_normal_text(self):
+        assert eink_display._sanitize_render_text("My Home 5G", "ssid") == "My Home 5G"
+        assert eink_display._sanitize_render_text(None, "ssid") == ""
+
+    @pytest.mark.parametrize("field", ["network name", "password"])
+    def test_over_budget_value_is_truncated_with_ellipsis_and_logged(self, caplog, field):
+        # Both the SSID and the password go through the clamp; each logs under
+        # its own field label so a truncation of either is attributable.
+        draw = ImageDraw.Draw(Image.new("1", eink_display.DISPLAY_SIZE, 255))
+        font = ImageFont.truetype(eink_display.FONT_PATH, 24)
+        long_value = "A" * 40  # overflows the value budget at 24pt
+        with caplog.at_level(logging.WARNING):
+            fitted = eink_display._clamp_to_width(long_value, font, draw, self.VALUE_BUDGET, field)
+        assert fitted.endswith("…")
+        assert draw.textlength(fitted, font=font) <= self.VALUE_BUDGET
+        assert any("too wide" in r.message and field in r.message for r in caplog.records)
+
+    def test_clamp_degenerate_inputs_never_crash(self):
+        # Empty string → "" (no ellipsis, no log); a budget smaller than one
+        # ellipsis glyph → the bare ellipsis (can't do better). Both terminate.
+        draw = ImageDraw.Draw(Image.new("1", eink_display.DISPLAY_SIZE, 255))
+        font = ImageFont.truetype(eink_display.FONT_PATH, 24)
+        assert eink_display._clamp_to_width("", font, draw, self.VALUE_BUDGET, "x") == ""
+        assert eink_display._clamp_to_width("anything", font, draw, 1, "x") == "…"
+
+    def test_within_budget_value_is_left_intact(self):
+        draw = ImageDraw.Draw(Image.new("1", eink_display.DISPLAY_SIZE, 255))
+        font = ImageFont.truetype(eink_display.FONT_PATH, 24)
+        # The default hotspot credentials must never be touched by the clamp.
+        for value in ("LitClock-Setup", "Abc12dEf"):
+            assert eink_display._clamp_to_width(value, font, draw, self.VALUE_BUDGET, "x") == value
+
+    def test_default_credentials_fit_the_value_budget_measured(self):
+        # The production-safe path: DEFAULT_SSID + an 8-char password render
+        # whole within the 510px right-column budget (mirrors the litclock-dev#588 label
+        # test, for the VALUES the renderer previously left unclamped).
+        draw = ImageDraw.Draw(Image.new("1", eink_display.DISPLAY_SIZE, 255))
+        font = ImageFont.truetype(eink_display.FONT_PATH, 24)
+        for value in ("LitClock-Setup", "Ab3xYz9q"):
+            assert draw.textlength(value, font=font) < self.VALUE_BUDGET
+
+    def test_font_fallback_passes_size_and_logs_not_a_silent_10px(self, monkeypatch, caplog):
+        # The regression: a missing fonts/ dir fell to bare load_default() → a
+        # 10px bitmap → a fully-painted but unreadable panel with a clean
+        # journal. The fallback must pass size= (>= the real sizes) AND log.
+        sizes_used = []
+        real_truetype = eink_display.ImageFont.truetype
+        real_load_default = eink_display.ImageFont.load_default
+
+        def only_our_fonts_fail(path, *args, **kwargs):
+            # Simulate a missing fonts/ dir: OUR Literata paths fail, but PIL's
+            # own bundled font (which load_default(size=) loads via truetype
+            # internally on Pillow >= 10) must still resolve.
+            if path in (eink_display.FONT_PATH, eink_display.FONT_PATH_BOLD):
+                raise OSError("fonts/ missing")
+            return real_truetype(path, *args, **kwargs)
+
+        def recording_load_default(*args, **kwargs):
+            sizes_used.append(kwargs.get("size"))
+            return real_load_default(*args, **kwargs)
+
+        monkeypatch.setattr(eink_display.ImageFont, "truetype", only_our_fonts_fail)
+        monkeypatch.setattr(eink_display.ImageFont, "load_default", recording_load_default)
+        with caplog.at_level(logging.ERROR):
+            img = eink_display.create_hotspot_display_image("LitClock-Setup", "Ab3xYz9q", "10.42.0.1")
+        assert img.size == eink_display.DISPLAY_SIZE
+        assert sizes_used and all(s is not None and s >= 18 for s in sizes_used), (
+            f"fallback fonts must pass size= (never the silent 10px default); got {sizes_used}"
+        )
+        assert any("fonts unavailable" in r.message for r in caplog.records)
+
+    def test_instructions_name_the_ssid_the_credential_block_shows(self):
+        # litclock-dev#589 item 2: the numbered steps must name the SAME network the
+        # credential block paints. Threading ssid through is what couples them;
+        # a hardcoded "LitClock-Setup" step under a different credential name is
+        # unreadable to the audience that can't tell two networks apart.
+        for is_retry, reason in [(False, None), (True, "wifi_password"), (True, "connect_failed")]:
+            lines = eink_display.setup_instruction_lines(
+                "10.42.0.1", ssid="CustomNet-9", is_retry=is_retry, retry_reason=reason
+            )
+            assert any("CustomNet-9" in ln for ln in lines), lines
+            assert not any("LitClock-Setup" in ln for ln in lines), lines
+
+    def test_hostile_ssid_renders_without_crashing(self):
+        # Long + newline + reserved chars: the render must degrade, not raise —
+        # a blank/crashed splash on the setup screen is the worst outcome.
+        img = eink_display.create_hotspot_display_image("X" * 40 + "\ntail;bad", "pw12345", "10.42.0.1")
+        assert img.size == eink_display.DISPLAY_SIZE
+        assert _count_black_pixels(img) > 0  # actually painted something
+
+    def test_full_render_keeps_value_lines_within_the_panel(self, monkeypatch):
+        # Integration guard (/review): the helper tests can't see whether
+        # create_hotspot_display_image actually APPLIES the clamp. Dropping it,
+        # or miscomputing value_budget, would still paint pixels. Capture what
+        # is drawn at the value column and assert nothing overflows x=800.
+        drawn = []
+        real_text = ImageDraw.ImageDraw.text
+
+        def capturing_text(self, xy, text, *args, **kwargs):
+            drawn.append((xy, text, kwargs.get("font")))
+            return real_text(self, xy, text, *args, **kwargs)
+
+        monkeypatch.setattr(ImageDraw.ImageDraw, "text", capturing_text)
+        eink_display.create_hotspot_display_image("Z" * 50, "Q" * 50, "10.42.0.1")
+
+        measure = ImageDraw.Draw(Image.new("1", eink_display.DISPLAY_SIZE, 255))
+        value_col = [(xy, t, f) for (xy, t, f) in drawn if xy[0] == self.VALUE_LEFT_EDGE]
+        assert value_col, "nothing drawn at the value column"
+        for xy, text, font in value_col:
+            right = xy[0] + measure.textlength(text, font=font)
+            assert right <= eink_display.DISPLAY_SIZE[0], f"{text!r} overflows the panel ({right}px > 800)"

--- a/tests/test_first_boot_flow.py
+++ b/tests/test_first_boot_flow.py
@@ -535,3 +535,100 @@ class TestSetupIncompletePoweroff:
         it was added for is complete."""
         assert 'wait_for_setup "$SERVER_PID" 1800' in content
         assert "FIRSTBOOT_SETUP_TIMEOUT" not in content
+
+
+class TestIssueBoxAlignment:
+    """litclock-dev#589 item 4 + litclock-dev#626: the /etc/issue console box
+    border must align with its content lines for EVERY credential pair the
+    create_hotspot boundary validation admits, not just the shipped defaults.
+    The box is now sized dynamically at runtime, so this test RUNS the real
+    update_issue_hotspot under bash (sudo/log/cp stubbed) instead of statically
+    re-deriving widths from the script text — a static check re-derived from
+    the template is blind to the exact runtime overflow it exists to catch."""
+
+    def _render(self, tmp_path, ssid, password, ip):
+        text = open(FIRST_BOOT_SH).read()
+        m = re.search(r"^update_issue_hotspot\(\) \{.*?^\}", text, re.S | re.M)
+        assert m, "update_issue_hotspot() not found in first-boot.sh"
+        # The regex stops at the first column-0 `}` — if the body ever gains
+        # one (or the closer is re-indented), the extraction truncates
+        # mid-heredoc and bash fails with a misattributed syntax error. The
+        # heredoc terminator inside the capture proves we got the whole
+        # function (/review).
+        assert "ISSUEEOF" in m.group(0), "extraction truncated before the heredoc terminator"
+        out = tmp_path / "issue.out"
+        harness = (
+            "log() { :; }\n"
+            "cp() { :; }\n"
+            'sudo() { if [[ "$1" == "tee" ]]; then cat > "$OUT"; else :; fi; }\n'
+            f"{m.group(0)}\n"
+            'update_issue_hotspot "$1" "$2" "$3"\n'
+        )
+        subprocess.run(
+            ["bash", "-c", harness, "issue-box-test", ssid, password, ip],
+            check=True,
+            env={**os.environ, "OUT": str(out)},
+            timeout=10,
+        )
+        return out.read_text()
+
+    def _assert_box_aligned(self, rendered):
+        box_lines = [ln for ln in rendered.splitlines() if ln.strip()[:1] in tuple("╔╠╚║")]
+        assert len(box_lines) == 7, f"expected a 7-line box, got {len(box_lines)}: {box_lines}"
+        widths = {len(ln) for ln in box_lines}
+        assert len(widths) == 1, f"box lines are not equal width: {sorted(widths)} in\n{rendered}"
+
+    def test_default_credentials_box_is_aligned_and_45_wide(self, tmp_path):
+        # The shipped path (14-char default SSID, 8-char password, IPv4 URL)
+        # must render the historical 45-col interior byte-for-byte.
+        rendered = self._render(tmp_path, "LitClock-Setup", "Ab3xYz9q", "10.42.0.1")
+        self._assert_box_aligned(rendered)
+        assert "║  LitClock's WiFi network: LitClock-Setup" in rendered
+        border = re.search(r"╔(═+)╗", rendered)
+        assert border and len(border.group(1)) == 45
+
+    def test_max_valid_credentials_grow_the_box_without_breaking_it(self, tmp_path):
+        # The widest pair validate_hotspot_credentials admits: a 32-char SSID
+        # and a 63-char password. The old fixed %-16s/%-15s fields overflowed
+        # the right border on exactly these; the box must grow instead —
+        # untruncated, because this banner exists so a tester can read the
+        # EXACT credentials.
+        ssid = "S" * 32
+        password = "p" * 63
+        rendered = self._render(tmp_path, ssid, password, "10.42.0.1")
+        self._assert_box_aligned(rendered)
+        assert ssid in rendered
+        assert password in rendered
+
+    def test_odd_width_title_centering_stays_aligned(self, tmp_path):
+        # A 62-char password makes interior 92 and interior-title 73 (odd), so
+        # pad_r = pad_l + 1 — the asymmetric centering branch no other case
+        # exercises. A refactor to symmetric padding would misalign the title
+        # row only on odd diffs and pass every even-diff test (/review).
+        rendered = self._render(tmp_path, "LitClock-Setup", "p" * 62, "10.42.0.1")
+        self._assert_box_aligned(rendered)
+
+    def test_first_growth_step_past_the_floor(self, tmp_path):
+        # 17-char SSID -> content 44 + 2 = 46, one past the 45 floor: the
+        # boundary between "floor holds" and "box grows" (/review).
+        rendered = self._render(tmp_path, "S" * 17, "Ab3xYz9q", "10.42.0.1")
+        self._assert_box_aligned(rendered)
+        border = re.search(r"╔(═+)╗", rendered)
+        assert border and len(border.group(1)) == 46
+
+    def test_long_ip_grows_the_box_via_the_url_line(self, tmp_path):
+        # The old %-30s URL field was the one surface with NO overflow guard
+        # (litclock-dev#626 item 3). Growth must also be drivable by the ip
+        # argument alone, not just the credential lines.
+        rendered = self._render(tmp_path, "LitClock-Setup", "Ab3xYz9q", "fe80::1234:5678:9abc:def0")
+        self._assert_box_aligned(rendered)
+        assert "http://fe80::1234:5678:9abc:def0:8080" in rendered
+
+    def test_backslash_password_is_doubled_for_agetty(self, tmp_path):
+        # agetty expands \d, \l, \e... in /etc/issue, so a backslash-bearing
+        # credential (printable ASCII — validator admits it) must be written
+        # DOUBLED or the console displays a different password than the AP
+        # uses, and \e is terminal-escape injection (/review, three passes).
+        rendered = self._render(tmp_path, "LitClock-Setup", "pa\\ss\\word1", "10.42.0.1")
+        assert "pa\\\\ss\\\\word1" in rendered, "backslashes must be doubled so getty shows the literal"
+        self._assert_box_aligned(rendered)

--- a/tests/test_setup_server.py
+++ b/tests/test_setup_server.py
@@ -733,6 +733,7 @@ class TestWifiScanCaching:
         # Reset cache state before each test
         setup_server._WIFI_SCAN_CACHE = None
         setup_server._WIFI_SCAN_TIME = 0
+        setup_server._WIFI_SCAN_SSIDS = frozenset()
 
     def test_cache_returns_cached_result(self, monkeypatch):
         """Second call within TTL returns cached result without scanning."""
@@ -747,10 +748,11 @@ class TestWifiScanCaching:
         monkeypatch.setitem(sys.modules, "wifi_provision", mock_wifi)
         monkeypatch.setattr(setup_server, "PROVISIONING_MODE", True)
 
-        result1 = setup_server._wifi_network_options()
-        result2 = setup_server._wifi_network_options()
+        result1, empty1 = setup_server._wifi_network_options()
+        result2, empty2 = setup_server._wifi_network_options()
 
         assert result1 == result2
+        assert (empty1, empty2) == (False, False)
         assert len(scan_count) == 1  # Only scanned once
         assert "TestNet" in result1
 
@@ -788,9 +790,109 @@ class TestWifiScanCaching:
         mock_wifi.scan_wifi_networks = lambda: []
         monkeypatch.setitem(sys.modules, "wifi_provision", mock_wifi)
 
-        result = setup_server._wifi_network_options()
+        result, was_empty = setup_server._wifi_network_options()
         assert "No networks found" in result
+        assert was_empty is True
         assert setup_server._WIFI_SCAN_CACHE is None
+
+    def test_page_build_empty_scan_preserves_scan_evidence(self, monkeypatch):
+        """The item-7 decision, pinned at the SECOND scan site (/review on
+        litclock-dev#614): the /scan-wifi handler test alone would stay green if this
+        function's empty branch started clearing _WIFI_SCAN_SSIDS — flipping
+        a previously-seen typed SSID to a permanent `hidden yes` profile."""
+        import sys
+        from unittest.mock import MagicMock
+
+        setup_server._WIFI_SCAN_SSIDS = frozenset({"homewifi"})
+        mock_wifi = MagicMock()
+        mock_wifi.scan_wifi_networks = lambda: []
+        monkeypatch.setitem(sys.modules, "wifi_provision", mock_wifi)
+
+        result, was_empty = setup_server._wifi_network_options()
+        assert was_empty is True
+        assert setup_server._WIFI_SCAN_SSIDS == frozenset({"homewifi"})
+
+    def test_scan_exception_returns_empty_flag_and_touches_nothing(self, monkeypatch):
+        """The except branch (nmcli dying) merges into the empty path today;
+        pin that it stays flagged empty and leaves cache + evidence alone
+        (/review on litclock-dev#614 — this branch had no direct test)."""
+        import sys
+        from unittest.mock import MagicMock
+
+        setup_server._WIFI_SCAN_SSIDS = frozenset({"homewifi"})
+        mock_wifi = MagicMock()
+
+        def boom():
+            raise RuntimeError("nmcli died")
+
+        mock_wifi.scan_wifi_networks = boom
+        monkeypatch.setitem(sys.modules, "wifi_provision", mock_wifi)
+
+        result, was_empty = setup_server._wifi_network_options()
+        assert was_empty is True
+        assert setup_server._WIFI_SCAN_CACHE is None
+        assert setup_server._WIFI_SCAN_SSIDS == frozenset({"homewifi"})
+
+    def test_concurrent_page_builds_scan_once_under_the_lock(self, monkeypatch):
+        """litclock-dev#615: _wifi_network_options must serialize scans under
+        _SCAN_CACHE_LOCK like /scan-wifi does. Two concurrent GET / builds at a
+        cold cache previously each fired their own nmcli rescan on the single
+        hotspot radio. With the lock, the second thread blocks, finds the fresh
+        cache on the recheck, and skips its scan — exactly one scan total.
+
+        The test forces overlap: both threads rendezvous at a barrier, then the
+        scan blocks briefly so the second thread is guaranteed to be waiting on
+        the lock (or the cache-hit recheck) while the first is mid-scan. Without
+        the lock this reliably records 2 scans; with it, 1.
+        """
+        import sys
+        import threading
+        import time
+        from unittest.mock import MagicMock
+
+        scan_count = []
+        count_lock = threading.Lock()
+        start = threading.Barrier(2)
+
+        def slow_scan():
+            # Each scan returns a DISTINCT SSID so the equality assertion below
+            # is meaningful: with the lock the waiter serves thread A's cached
+            # snapshot (identical results); a lockless mutant scans a second
+            # time and returns a different SSID (results differ AND count == 2).
+            with count_lock:
+                n = len(scan_count)
+                scan_count.append(1)
+            time.sleep(0.2)  # hold the radio long enough for the other thread to pile up
+            return [{"ssid": f"TestNet{n}", "signal": 80, "security": "WPA2"}]
+
+        mock_wifi = MagicMock()
+        mock_wifi.scan_wifi_networks = slow_scan
+        monkeypatch.setitem(sys.modules, "wifi_provision", mock_wifi)
+        monkeypatch.setattr(setup_server, "PROVISIONING_MODE", True)
+
+        results = []
+        res_lock = threading.Lock()
+
+        def worker():
+            start.wait()
+            r, _ = setup_server._wifi_network_options()
+            with res_lock:
+                results.append(r)
+
+        # daemon=True so a genuine deadlock (thread stuck on the lock) surfaces as
+        # a test failure via the is_alive assert instead of hanging interpreter exit.
+        threads = [threading.Thread(target=worker, daemon=True) for _ in range(2)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=5)
+
+        assert all(not t.is_alive() for t in threads), "a page build deadlocked on the scan lock"
+        assert len(scan_count) == 1, f"expected one serialized scan, got {len(scan_count)}"
+        assert len(results) == 2
+        assert "TestNet0" in results[0] and "TestNet0" in results[1], (
+            "the waiter did not serve the first scan's cached snapshot"
+        )
 
     def test_own_hotspot_ssid_filtered_out(self, monkeypatch):
         """The clock's own setup-hotspot SSID is never offered as a join target.
@@ -812,9 +914,10 @@ class TestWifiScanCaching:
         monkeypatch.setattr(setup_server, "PROVISIONING_MODE", True)
         monkeypatch.setattr(setup_server, "HOTSPOT_SSID", "LitClock-Setup")
 
-        result = setup_server._wifi_network_options()
+        result, was_empty = setup_server._wifi_network_options()
         assert "LitClock-Setup" not in result
         assert "HomeWiFi" in result
+        assert was_empty is False
 
     def test_no_filter_when_hotspot_ssid_unset(self, monkeypatch):
         """In normal (non-provisioning) mode HOTSPOT_SSID is None — filter is a
@@ -828,7 +931,7 @@ class TestWifiScanCaching:
         monkeypatch.setitem(sys.modules, "wifi_provision", mock_wifi)
         monkeypatch.setattr(setup_server, "HOTSPOT_SSID", None)
 
-        result = setup_server._wifi_network_options()
+        result, _ = setup_server._wifi_network_options()
         assert "LitClock-Setup" in result
 
     def test_filter_emptying_list_returns_no_networks_uncached(self, monkeypatch):
@@ -845,9 +948,10 @@ class TestWifiScanCaching:
         monkeypatch.setattr(setup_server, "PROVISIONING_MODE", True)
         monkeypatch.setattr(setup_server, "HOTSPOT_SSID", "LitClock-Setup")
 
-        result = setup_server._wifi_network_options()
+        result, was_empty = setup_server._wifi_network_options()
         assert "No networks found" in result
         assert "LitClock-Setup" not in result
+        assert was_empty is True
         assert setup_server._WIFI_SCAN_CACHE is None
 
     def test_scan_wifi_endpoint_filters_own_hotspot(self, monkeypatch):
@@ -884,6 +988,98 @@ class TestWifiScanCaching:
         assert setup_server._WIFI_SCAN_CACHE is not None
         assert "LitClock-Setup" not in setup_server._WIFI_SCAN_CACHE
         assert "HomeWiFi" in setup_server._WIFI_SCAN_CACHE
+
+    def test_scan_wifi_endpoint_updates_scan_evidence(self, monkeypatch):
+        """litclock-dev#605 item 7: _WIFI_SCAN_SSIDS was only ever asserted
+        by monkeypatching it directly — nothing pinned that the /scan-wifi
+        HANDLER feeds it. It must: the wifi_hidden decision in do_POST reads
+        this set, and a Refresh tap is how a user proves a typed name is
+        visible."""
+        import sys
+        from unittest.mock import MagicMock
+
+        mock_wifi = MagicMock()
+        mock_wifi.scan_wifi_networks = lambda: [{"ssid": "HomeWiFi", "signal": 70, "security": "WPA2"}]
+        monkeypatch.setitem(sys.modules, "wifi_provision", mock_wifi)
+        monkeypatch.setattr(setup_server, "PROVISIONING_MODE", True)
+
+        handler = _make_handler()
+        handler.path = "/scan-wifi"
+        handler.headers = {"Host": "litclock.setup"}
+        handler.send_json = lambda payload: None
+        handler.do_GET()
+
+        assert "homewifi" in setup_server._WIFI_SCAN_SSIDS
+
+    def test_empty_rescan_preserves_scan_evidence(self, monkeypatch):
+        """Pins the litclock-dev#605 item 7 decision: an empty rescan must
+        NOT clear _WIFI_SCAN_SSIDS. Evidence accumulated from non-empty scans
+        stays valid across empty rescans — clearing it would flip a typed,
+        previously-seen name to `hidden yes`, which nmcli writes into the saved
+        profile as a PERMANENT probe-request leak. Stale visibility evidence is
+        transient; the leak is not."""
+        import sys
+        from unittest.mock import MagicMock
+
+        setup_server._WIFI_SCAN_SSIDS = frozenset({"homewifi"})
+        mock_wifi = MagicMock()
+        mock_wifi.scan_wifi_networks = lambda: []
+        monkeypatch.setitem(sys.modules, "wifi_provision", mock_wifi)
+        monkeypatch.setattr(setup_server, "PROVISIONING_MODE", True)
+
+        handler = _make_handler()
+        handler.path = "/scan-wifi"
+        handler.headers = {"Host": "litclock.setup"}
+        sent = {}
+        handler.send_json = lambda payload: sent.update(networks=payload)
+        handler.do_GET()
+
+        assert sent["networks"] == []
+        assert setup_server._WIFI_SCAN_SSIDS == frozenset({"homewifi"})
+        # Empty results are also never cached — the next call retries.
+        assert setup_server._WIFI_SCAN_CACHE is None
+
+    def test_non_empty_scan_unions_into_evidence_not_replaces(self, monkeypatch):
+        """litclock-dev#615: scan evidence accumulates (UNION), it does not
+        replace. A network genuinely visible earlier this session can be absent
+        from a later scan (radio flicker); a replace would drop it and flip a
+        typed, previously-seen name to a permanent `hidden yes` probe leak. The
+        later scan's SSID must be ADDED, and the earlier one must SURVIVE."""
+        import sys
+        from unittest.mock import MagicMock
+
+        # 'homewifi' was seen in an earlier scan; this scan sees only 'neighbor'.
+        setup_server._WIFI_SCAN_SSIDS = frozenset({"homewifi"})
+        mock_wifi = MagicMock()
+        mock_wifi.scan_wifi_networks = lambda: [{"ssid": "Neighbor", "signal": 60, "security": "WPA2"}]
+        monkeypatch.setitem(sys.modules, "wifi_provision", mock_wifi)
+        monkeypatch.setattr(setup_server, "PROVISIONING_MODE", True)
+
+        handler = _make_handler()
+        handler.path = "/scan-wifi"
+        handler.headers = {"Host": "litclock.setup"}
+        handler.send_json = lambda payload: None
+        handler.do_GET()
+
+        # Union: the flickered-away 'homewifi' survives, 'neighbor' is added.
+        assert setup_server._WIFI_SCAN_SSIDS == frozenset({"homewifi", "neighbor"})
+
+    def test_page_build_scan_unions_into_evidence(self, monkeypatch):
+        """The union write in the OTHER scan site (_wifi_network_options / the
+        page build) must accumulate too, not just the /scan-wifi handler."""
+        import sys
+        from unittest.mock import MagicMock
+
+        setup_server._WIFI_SCAN_CACHE = None
+        setup_server._WIFI_SCAN_TIME = 0
+        setup_server._WIFI_SCAN_SSIDS = frozenset({"homewifi"})
+        mock_wifi = MagicMock()
+        mock_wifi.scan_wifi_networks = lambda: [{"ssid": "Neighbor", "signal": 60, "security": "WPA2"}]
+        monkeypatch.setitem(sys.modules, "wifi_provision", mock_wifi)
+        monkeypatch.setattr(setup_server, "PROVISIONING_MODE", True)
+
+        setup_server._wifi_network_options()
+        assert setup_server._WIFI_SCAN_SSIDS == frozenset({"homewifi", "neighbor"})
 
 
 # ── HTML_ERROR template ────────────────────────────────────────────
@@ -1000,13 +1196,28 @@ class TestWifiErrorBanner:
         EPIC litclock-dev#383 dropped the 'home' qualifier (which was scary jargon for
         non-tech users — issue litclock-dev#384); litclock-dev#555 dropped "hotspot"
         for the same reason. The disambiguation itself is still
-        load-bearing copy — only the word for it changed."""
+        load-bearing copy — only the word for it changed.
+
+        litclock-dev#610 review: this test used to pass a plain string and
+        match "wifi password" anywhere on the page — which the form's own
+        helper text satisfies, so it pinned nothing about the banner. The
+        disambiguation advice now renders only for the bad_password class,
+        and the assertions slice the banner region."""
+        import wifi_provision
+
         monkeypatch.setattr(setup_server, "PROVISIONING_MODE", True)
         monkeypatch.setattr(setup_server, "WIFI_CONNECT_IN_FLIGHT", False)
-        monkeypatch.setattr(setup_server, "WIFI_CONNECT_ERROR", "wrong password")
+        monkeypatch.setattr(
+            setup_server,
+            "WIFI_CONNECT_ERROR",
+            wifi_provision.WifiFailure("Incorrect WiFi password", wifi_provision.WIFI_FAIL_BAD_PASSWORD),
+        )
         html = setup_server._build_setup_html()
-        assert "wifi password" in html.lower()
-        assert "password shown on the clock" in html.lower()
+        banner_start = html.index("Couldn&rsquo;t join your WiFi")
+        banner_end = html.index("</div>", banner_start)
+        banner = html[banner_start:banner_end].lower()
+        assert "wifi password" in banner
+        assert "password shown on the clock" in banner
         # Regression: the dropped "home" qualifier must not creep back in.
         assert "home wifi" not in html.lower()
 
@@ -1597,27 +1808,63 @@ class TestRestoreHotspot:
     a failed-WiFi-password retry. These tests pin the behavior so a future
     refactor doesn't silently regress the UX."""
 
-    def test_restore_hotspot_refreshes_display_with_retry_reason(self, monkeypatch):
-        """Happy path: hotspot restore succeeds, display_hotspot_info is
-        called with retry_reason=HOTSPOT_RETRY_WIFI_PASSWORD."""
+    def _mock_eink(self, monkeypatch):
         import sys
+        from unittest.mock import MagicMock
+
+        mock_eink = MagicMock()
+        mock_eink.HOTSPOT_RETRY_WIFI_PASSWORD = "wifi_password"
+        mock_eink.HOTSPOT_RETRY_CONNECT_FAILED = "connect_failed"
+        monkeypatch.setitem(sys.modules, "eink_display", mock_eink)
+        return mock_eink
+
+    def test_restore_hotspot_bad_password_selects_the_password_variant(self, monkeypatch):
+        """litclock-dev#603: the wrong-password steps render only when the
+        failure actually WAS the password."""
         from unittest.mock import MagicMock
 
         monkeypatch.setattr(setup_server, "HOTSPOT_SSID", "LitClock-Setup")
         monkeypatch.setattr(setup_server, "HOTSPOT_PASSWORD", "abc12345")
 
         create_hotspot = MagicMock(return_value={"ssid": "x", "password": "y", "ip": "z"})
+        mock_eink = self._mock_eink(monkeypatch)
 
-        mock_eink = MagicMock()
-        mock_eink.HOTSPOT_RETRY_WIFI_PASSWORD = "wifi_password"
-        monkeypatch.setitem(sys.modules, "eink_display", mock_eink)
-
-        setup_server._restore_hotspot(create_hotspot)
+        setup_server._restore_hotspot(create_hotspot, failure_class="bad_password")
 
         create_hotspot.assert_called_once_with(ssid="LitClock-Setup", password="abc12345")
         mock_eink.display_hotspot_info.assert_called_once()
         kwargs = mock_eink.display_hotspot_info.call_args.kwargs
         assert kwargs.get("retry_reason") == "wifi_password"
+
+    @pytest.mark.parametrize("failure_class", ["timeout", "not_found", "other", "no_ip", None])
+    def test_restore_hotspot_non_password_failures_select_the_neutral_variant(self, monkeypatch, failure_class):
+        """litclock-dev#603 — the bug this closes: a timeout painted
+        wrong-password guidance. Every non-password class (and the
+        no-evidence None) gets the class-neutral connect-failed steps;
+        telling a user to retype a password that was never the problem
+        sends them fixing the one thing known-least-likely broken."""
+        from unittest.mock import MagicMock
+
+        monkeypatch.setattr(setup_server, "HOTSPOT_SSID", "LitClock-Setup")
+        monkeypatch.setattr(setup_server, "HOTSPOT_PASSWORD", "abc12345")
+
+        create_hotspot = MagicMock(return_value={"ssid": "x", "password": "y", "ip": "z"})
+        mock_eink = self._mock_eink(monkeypatch)
+
+        setup_server._restore_hotspot(create_hotspot, failure_class=failure_class)
+
+        kwargs = mock_eink.display_hotspot_info.call_args.kwargs
+        assert kwargs.get("retry_reason") == "connect_failed"
+
+    def test_bad_password_literal_is_in_lockstep_with_wifi_provision(self):
+        """_restore_hotspot and the banner compare against the literal
+        'bad_password' (a lazy constant import would be swallowed by the
+        ImportError arm under the fake wifi_provision the retry tests
+        inject). This pins the literal to the real constant so they can't
+        drift apart."""
+        import wifi_provision
+
+        assert wifi_provision.WIFI_FAIL_BAD_PASSWORD == "bad_password"
 
     def test_restore_hotspot_swallows_eink_display_failure(self, monkeypatch):
         """If the e-ink display call raises (dev machine without hardware,
@@ -2016,9 +2263,10 @@ class TestWifiPickerPlaceholderAndSort:
         mock_wifi.scan_wifi_networks = lambda: []
         monkeypatch.setitem(sys.modules, "wifi_provision", mock_wifi)
 
-        result = setup_server._wifi_network_options()
+        result, was_empty = setup_server._wifi_network_options()
         assert setup_server.MANUAL_SSID_VALUE in result
         assert setup_server.WIFI_PLACEHOLDER_EMPTY_TEXT in result
+        assert was_empty is True
         assert setup_server._WIFI_SCAN_CACHE is None
 
     def test_ssid_is_escaped_in_both_value_and_label(self):
@@ -2182,6 +2430,20 @@ class TestWifiPickerReviewHardening:
         script = self._script()
         assert script.count("appendManualOption(select)") >= 3
 
+    def test_ajax_empty_refresh_opens_the_manual_disclosure(self):
+        """litclock-dev#615: the server-rendered empty-scan path force-opens the
+        manual-SSID <details>, but a Refresh returning [] only swapped the
+        placeholder — the hidden-network user who taps Refresh into an empty
+        scan was left with the type-it-in field folded away. The empty branch
+        must now open it too. (Reverting the one JS line left the suite green.)"""
+        script = self._script()
+        empty_branch = script[script.index("networks.length === 0") :]
+        empty_branch = empty_branch[
+            : empty_branch.index("} else {") if "} else {" in empty_branch else len(empty_branch)
+        ]
+        assert "getElementById('manual-ssid')" in empty_branch
+        assert "details.open = true" in empty_branch
+
     def test_onssidchange_is_defined_and_wired(self):
         """Deleting the onchange attribute left every test green while
         silently killing the one path this feature exists to add: the
@@ -2255,20 +2517,26 @@ class TestWifiPickerReviewHardening:
     # ── Byte budget, stated in bytes ──
 
     def test_manual_input_carries_a_client_side_length_guard(self):
-        """maxlength counts UTF-16 code units; SSID_MAX_BYTES counts bytes.
-        The two are decoupled in the source so a future change to the byte
-        budget doesn't silently move a character limit.
-
-        Honest limitation: this cannot distinguish the literal from the
-        constant, because SSID_MAX_BYTES is 32 today and both render
-        `maxlength="32"`. Mutation confirms it — that swap is an equivalent
-        mutant at the HTML level. What IS pinned here is that the attribute
-        exists and sits on the manual SSID input; the decoupling itself rests
-        on the comment at SSID_MAX_BYTES and on the server-side byte check,
-        which its own tests do pin."""
+        """The attribute interpolates SSID_MAX_BYTES (litclock-dev#605 item
+        12 — it was a re-typed literal before, exactly the drift the
+        constant exists to prevent). maxlength counts UTF-16 code units
+        while the budget is bytes, so for multi-byte names the client guard
+        is looser than the server's — deliberate: it stops the all-ASCII
+        case early, and the do_POST byte check (pinned by its own tests) is
+        the real gate."""
         html = setup_server._build_setup_html()
-        at = html.index('maxlength="32"')
+        at = html.index(f'maxlength="{setup_server.SSID_MAX_BYTES}"')
         assert setup_server.MANUAL_SSID_FIELD in html[at - 400 : at], "maxlength must sit on the manual SSID input"
+
+    def test_maxlength_actually_interpolates_the_constant(self, monkeypatch):
+        """Kills the equivalent mutant the assertion above cannot: with
+        SSID_MAX_BYTES = 32, a re-typed literal renders identically. A
+        sentinel value proves the attribute reads the constant at build
+        time (/review on litclock-dev#614 — the item-12 fix was otherwise untestable)."""
+        monkeypatch.setattr(setup_server, "SSID_MAX_BYTES", 48)
+        html = setup_server._build_setup_html()
+        assert 'maxlength="48"' in html
+        assert 'maxlength="32"' not in html
 
 
 class TestScannedSsids:
@@ -2483,3 +2751,52 @@ class TestNoHotspotJargonAcrossSurfaces:
             script = (self.REPO / "scripts" / name).read_text()
             for echoed in re.findall(r'echo\s+(?:-e\s+)?"([^"]*)"', script):
                 assert "hotspot" not in echoed.lower(), f"{name}: {echoed}"
+
+
+# ── litclock-dev#603: retry instruction variants ────────────────────
+
+
+class TestRetryInstructionVariants:
+    """The connect-failed retry steps. Importable on dev machines:
+    eink_display needs Pillow at import time, not the waveshare driver,
+    so this copy is testable outside tests/test_eink_display.py."""
+
+    def test_connect_failed_variant_has_no_password_step(self):
+        import eink_display
+
+        lines = eink_display.setup_instruction_lines(
+            "10.42.0.1", is_retry=True, retry_reason=eink_display.HOTSPOT_RETRY_CONNECT_FAILED
+        )
+        joined = " ".join(lines)
+        # The whole point: no password guidance when the password wasn't
+        # the failure. Radio-physical causes lead instead.
+        assert "password" not in joined.lower()
+        assert any("2.4GHz" in ln for ln in lines)
+        assert lines[0].startswith("1. Rescan the QR code")
+        # Fallback URLs keep the explicit scheme (litclock-dev#588 rules).
+        assert "http://" in lines[-1]
+
+    def test_password_variant_copy_is_unchanged(self):
+        import eink_display
+
+        lines = eink_display.setup_instruction_lines(
+            "10.42.0.1", is_retry=True, retry_reason=eink_display.HOTSPOT_RETRY_WIFI_PASSWORD
+        )
+        assert any("WiFi password" in ln for ln in lines)
+
+    def test_retry_without_reason_keeps_the_password_copy(self):
+        """Backward compat: is_retry=True with no reason is the pre-#603
+        call shape — it must keep rendering what it always rendered."""
+        import eink_display
+
+        lines = eink_display.setup_instruction_lines("10.42.0.1", is_retry=True)
+        assert any("WiFi password" in ln for ln in lines)
+
+    def test_both_retry_reasons_render_the_retry_title(self):
+        """display_hotspot_info's is_retry gate must accept BOTH variants —
+        a connect_failed reason that fell through to the non-retry splash
+        would paint first-boot setup copy over a failed join."""
+        import eink_display
+
+        assert eink_display.HOTSPOT_RETRY_CONNECT_FAILED == "connect_failed"
+        assert eink_display.HOTSPOT_RETRY_WIFI_PASSWORD == "wifi_password"

--- a/tests/test_wifi_provision.py
+++ b/tests/test_wifi_provision.py
@@ -11,6 +11,8 @@ wave these cases through and surface the misleading nmcli error.
 
 from __future__ import annotations
 
+import re
+import string
 import subprocess
 from types import SimpleNamespace
 
@@ -135,6 +137,103 @@ def test_create_hotspot_bails_when_not_ready(monkeypatch):
     result = wifi_provision.create_hotspot(ssid="test", password="testpass")
     assert result is None
     assert called == [], "create_hotspot should not run any side effects when wlan0 is not ready"
+
+
+class TestValidateHotspotCredentials:
+    """litclock-dev#626: out-of-spec credentials are rejected where the AP is
+    created, so the live AP, the e-ink QR, the /etc/issue banner, and the
+    splash step lines can never disagree about what the network is."""
+
+    def test_shipped_defaults_are_valid(self):
+        # The production path: DEFAULT_SSID + a generated 8-char password.
+        pw = wifi_provision._generate_password()
+        assert wifi_provision.validate_hotspot_credentials(wifi_provision.DEFAULT_SSID, pw) is None
+
+    def test_generated_password_invariants_are_pinned(self):
+        # Don't just sample one random draw: pin the generator's contract so a
+        # future alphabet change that could emit a validator-rejected char
+        # fails deterministically (/review, Codex). Length 8, alnum ASCII, and
+        # every char of the drawing alphabet is itself validator-clean.
+        pw = wifi_provision._generate_password()
+        assert len(pw) == 8 and pw.isalnum() and pw.isascii()
+        alphabet = string.ascii_letters + string.digits
+        assert set(pw) <= set(alphabet)
+        for ch in alphabet:
+            assert wifi_provision.validate_hotspot_credentials(wifi_provision.DEFAULT_SSID, ch * 8) is None
+
+    def test_boundary_lengths_are_valid(self):
+        assert wifi_provision.validate_hotspot_credentials("S" * 32, "p" * 8) is None
+        assert wifi_provision.validate_hotspot_credentials("S", "p" * 63) is None
+
+    def test_ssid_over_32_chars_rejected(self):
+        error = wifi_provision.validate_hotspot_credentials("S" * 33, "p" * 8)
+        assert error and "33" in error
+
+    def test_empty_or_blank_ssid_rejected(self):
+        # All-spaces is as bad as empty: invisible on every surface, and phone
+        # QR parsers whitespace-trim the payload (/review adversarial pass).
+        for bad in ("", "   "):
+            assert "blank" in wifi_provision.validate_hotspot_credentials(bad, "p" * 8)
+
+    def test_control_chars_in_ssid_rejected(self):
+        # A newline here is the exact QR-vs-AP divergence litclock-dev#589 renders
+        # around: nmcli would create the AP with the raw value while the QR
+        # encodes the sanitized one.
+        for bad in ("Lit\nClock", "Lit\rClock", "Lit\x00Clock", "Lit\u2028Clock"):
+            error = wifi_provision.validate_hotspot_credentials(bad, "p" * 8)
+            assert error and "ASCII" in error
+
+    def test_non_ascii_ssid_rejected(self):
+        # Deliberately tighter than 802.11 (/review, three passes converged):
+        # Aileron has no CJK/emoji glyphs (tofu on the e-ink), bash pads the
+        # /etc/issue box by bytes while counting chars, and phone QR parsers
+        # mangle non-ASCII -- ASCII is the one alphabet where every surface
+        # renders the same name.
+        for bad in ("Caf\u00e9 WiFi 5G", "\u65e5" * 10 + "ab"):
+            error = wifi_provision.validate_hotspot_credentials(bad, "p" * 8)
+            assert error and "ASCII" in error
+
+    def test_ssid_with_spaces_is_valid(self):
+        assert wifi_provision.validate_hotspot_credentials("My Home 5G", "p" * 8) is None
+
+    def test_missing_password_returns_error_not_raise(self):
+        # The validator reads as public API: None/empty must yield an error
+        # string, never a TypeError (/review adversarial pass).
+        assert "missing" in wifi_provision.validate_hotspot_credentials("LitClock-Setup", None)
+        assert "missing" in wifi_provision.validate_hotspot_credentials("LitClock-Setup", "")
+
+    def test_password_length_bounds_rejected(self):
+        # WPA2-PSK passphrases are 8-63 chars; the error must not echo the value.
+        for bad in ("p" * 7, "p" * 64):
+            error = wifi_provision.validate_hotspot_credentials("LitClock-Setup", bad)
+            assert error and "8-63" in error
+            assert bad not in error
+
+    def test_password_outside_printable_ascii_rejected(self):
+        for bad in ("pässword", "pass\tword1", "password\x00"):
+            error = wifi_provision.validate_hotspot_credentials("LitClock-Setup", bad)
+            assert error and "ASCII" in error
+            assert bad not in error
+
+
+def test_create_hotspot_rejects_invalid_credentials_before_any_side_effect(monkeypatch):
+    """litclock-dev#626: a rejected pair must leave the system exactly as it
+    was — no hotspot teardown, no captive-portal config, no nmcli, not even
+    the wifi-ready probe."""
+    called = []
+
+    def should_not_run(*args, **kwargs):
+        called.append(args)
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(wifi_provision, "ensure_wifi_ready", should_not_run)
+    monkeypatch.setattr(wifi_provision, "teardown_hotspot", should_not_run)
+    monkeypatch.setattr(wifi_provision, "_setup_captive_portal", should_not_run)
+    monkeypatch.setattr(wifi_provision, "_run_nmcli", should_not_run)
+
+    assert wifi_provision.create_hotspot(ssid="Lit\nClock", password="p" * 8) is None
+    assert wifi_provision.create_hotspot(ssid="LitClock-Setup", password="short") is None
+    assert called == [], "create_hotspot must reject invalid credentials before any side effect"
 
 
 def test_captive_portal_dnsmasq_config_has_no_resolv(monkeypatch):
@@ -262,21 +361,54 @@ class TestConnectToWifiHidden:
     otherwise cannot, but not one to impose on the ordinary path.
     """
 
-    def _patch(self, monkeypatch, returncode=0, stderr="", connected=True):
+    def _patch(
+        self,
+        monkeypatch,
+        returncode=0,
+        stderr="",
+        connected=True,
+        uuids_before=(),
+        uuids_created=(),
+        uuids_show_rc=0,
+        delete_rc=0,
+        disconnect_rc=0,
+        expected_connect_timeout=30,
+    ):
         """``connected`` drives is_wifi_connected: True short-circuits the
         post-connect IP wait (success paths); False is required by the
         timeout-delete tests, because the rescue check (litclock-dev#600 review) treats
-        a live connection after the bound as success, not as a cleanup case."""
+        a live connection after the bound as success, not as a cleanup case.
+
+        litclock-dev#595 per-command scripting: the UUID listing reports
+        ``uuids_before`` until the CONNECT call has been observed, and
+        ``uuids_before + uuids_created`` after it — keyed on the connect,
+        not on call count, so a snapshot taken on the wrong side of the
+        connect reads the wrong set and fails (a call-count key let the
+        snapshot-after-connect mutation pass the whole suite — litclock-dev#609
+        testing-specialist finding). ``uuids_show_rc`` != 0 fails the
+        listing (snapshot/diff unavailable); ``delete_rc`` / ``disconnect_rc``
+        script those commands' outcomes."""
         calls: list[list[str]] = []
         timeouts: list = []
+        connect_seen = {"v": False}
 
-        def fake_run(args, check=True, sudo=False, timeout=None):
+        def fake_run(args, check=True, sudo=False, timeout=None, **_kw):
             calls.append(list(args))
             timeouts.append(timeout)
+            if args == ["-t", "-f", "UUID", "connection", "show"]:
+                if uuids_show_rc:
+                    return SimpleNamespace(returncode=uuids_show_rc, stdout="", stderr="cannot list")
+                uuids = list(uuids_before) + (list(uuids_created) if connect_seen["v"] else [])
+                return SimpleNamespace(returncode=0, stdout="".join(f"{u}\n" for u in uuids), stderr="")
+            if "delete" in args:
+                return SimpleNamespace(returncode=delete_rc, stdout="", stderr="")
+            if args == ["device", "disconnect", "wlan0"]:
+                return SimpleNamespace(returncode=disconnect_rc, stdout="", stderr="")
             # The connect call must carry the litclock-dev#598 activation bound
             # (hardware-measured ~107s hang on exists-but-hidden SSIDs).
             if "connect" in args:
-                assert timeout == 30, "connect must be bounded (litclock-dev#598)"
+                connect_seen["v"] = True
+                assert timeout == expected_connect_timeout, "connect must carry the expected bound (litclock-dev#598)"
             return SimpleNamespace(returncode=returncode, stdout="", stderr=stderr)
 
         self.timeouts = timeouts
@@ -323,56 +455,75 @@ class TestConnectToWifiHidden:
         assert "case-sensitive" in err  # spelling hint retained
         assert err.index("2.4GHz") < err.index("case-sensitive")
 
-    def test_connect_timeout_returns_honest_copy_and_deletes_profile(self, monkeypatch):
-        """litclock-dev#598: the bounded connect (synthetic returncode 124)
-        must (a) tell the user the network didn't answer — not blame their
-        spelling — and (b) delete the half-created profile: the kill only
-        reaches the sudo wrapper and NetworkManager's activation job keeps
-        running, so this delete is the one thing that aborts it AND drops
-        the armed profile (the litclock-dev#595 class)."""
+    def test_connect_timeout_returns_honest_copy_aborts_and_deletes_created(self, monkeypatch):
+        """litclock-dev#598 + litclock-dev#609 review: the bounded connect (synthetic
+        returncode 124) must (a) tell the user the network didn't answer —
+        not blame their spelling — (b) abort the still-running activation at
+        the DEVICE (the kill only reaches the sudo wrapper; NM keeps trying,
+        and a delete only doubles as abort when the activated profile
+        happens to be named the SSID), and (c) delete the profile this
+        attempt created, identified by UUID diff — which also covers NM
+        uniquifying a colliding name ("MyNet 1")."""
         calls = self._patch(
-            monkeypatch, returncode=wifi_provision.NMCLI_TIMEOUT_RC, stderr="nmcli timed out", connected=False
+            monkeypatch,
+            returncode=wifi_provision.NMCLI_TIMEOUT_RC,
+            stderr="nmcli timed out",
+            connected=False,
+            uuids_before=("u-old",),
+            uuids_created=("u-new",),
         )
         ok, err = wifi_provision.connect_to_wifi("HiddenNet", "pw", hidden=True)
         assert ok is False
         assert "didn't answer in time" in err
         assert "case-sensitive" not in err  # spelling is not the story here
+        disconnect_idx = [i for i, c in enumerate(calls) if c == ["device", "disconnect", "wlan0"]]
+        assert disconnect_idx, "timeout must abort the activation at the device"
+        # The abort must stay bounded — an unbounded call against the same
+        # wedged NetworkManager would recreate the very hang this timeout
+        # exists to prevent, on the cleanup path.
+        assert self.timeouts[disconnect_idx[0]] == 10
         delete_idx = [i for i, c in enumerate(calls) if "delete" in c]
-        assert delete_idx, "timeout must trigger the profile delete"
+        assert delete_idx, "timeout must delete the created profile"
         delete = calls[delete_idx[0]]
-        # Explicit "id" selector — bare `delete <ssid>` lets nmcli spec-guess,
-        # and an SSID named "id"/"uuid"/"path" would break the cleanup.
-        assert delete[delete.index("delete") + 1 :] == ["id", "HiddenNet"]
-        # The delete itself must stay bounded — an unbounded delete against
-        # the same wedged NetworkManager would recreate the very hang this
-        # timeout exists to prevent, on the cleanup path.
+        assert delete[delete.index("delete") + 1 :] == ["uuid", "u-new"]
         assert self.timeouts[delete_idx[0]] == 10
+        # And never the pre-existing profile's UUID.
+        assert not any("u-old" in c for c in calls if "delete" in c)
 
     def test_connect_timeout_on_scanned_network_also_cleans_up(self, monkeypatch):
         """The rc-124 branch fires before the hidden/typed split — a scanned
         pick that times out needs the same honest copy and the same profile
         cleanup, and must keep needing them if the branch ever moves."""
         calls = self._patch(
-            monkeypatch, returncode=wifi_provision.NMCLI_TIMEOUT_RC, stderr="nmcli timed out", connected=False
+            monkeypatch,
+            returncode=wifi_provision.NMCLI_TIMEOUT_RC,
+            stderr="nmcli timed out",
+            connected=False,
+            uuids_created=("u-x",),
         )
         ok, err = wifi_provision.connect_to_wifi("HomeWiFi", "pw")
         assert ok is False
         assert "didn't answer in time" in err
-        assert any("delete" in c and "HomeWiFi" in c for c in calls)
+        assert any("delete" in c and "u-x" in c for c in calls)
 
     def test_connect_timeout_rescues_a_join_that_landed_late(self, monkeypatch):
         """litclock-dev#600 review: the kill never stops NM's activation, so a slow-but-
         genuine join (mesh/band-steering DHCP takes 30-45s) can land AFTER
         the bound. Deleting then would tear down a working connection and
         every retry would collide identically — the network becomes
-        permanently unprovisionable. A landed join is a success, and the
-        half-created-profile delete must NOT run."""
+        permanently unprovisionable. A landed join is a success: no delete,
+        and no device disconnect either (it would tear down the join)."""
         calls = self._patch(
-            monkeypatch, returncode=wifi_provision.NMCLI_TIMEOUT_RC, stderr="nmcli timed out", connected=True
+            monkeypatch,
+            returncode=wifi_provision.NMCLI_TIMEOUT_RC,
+            stderr="nmcli timed out",
+            connected=True,
+            uuids_created=("u-live",),
         )
         ok, err = wifi_provision.connect_to_wifi("HiddenNet", "pw", hidden=True)
         assert (ok, err) == (True, None)
         assert not any("delete" in c for c in calls), "rescued join must not delete the live profile"
+        assert ["device", "disconnect", "wlan0"] not in calls, "rescued join must not be disconnected"
 
     def test_connect_timeout_rescue_requires_the_target_ssid(self, monkeypatch):
         """Connected-to-something isn't rescued — only the SSID this attempt
@@ -391,7 +542,7 @@ class TestConnectToWifiHidden:
         silent (this repo has shipped that exact swallow before)."""
         calls: list[list[str]] = []
 
-        def fake_run(args, check=True, sudo=False, timeout=None):
+        def fake_run(args, check=True, sudo=False, timeout=None, **_kw):
             calls.append(list(args))
             # Connect times out; the cleanup delete then fails too.
             return SimpleNamespace(returncode=wifi_provision.NMCLI_TIMEOUT_RC, stdout="", stderr="nmcli timed out")
@@ -435,6 +586,714 @@ class TestConnectToWifiHidden:
         assert "case-sensitive" not in err
         assert "'HomeWiFi' not found" in err
 
+    # ── litclock-dev#595: failed attempts must not leave armed profiles ──
+    # (in this class rather than a subclass so pytest doesn't re-run the
+    # whole fixture surface twice — the litclock-dev#605 item-8 lesson.)
+
+    def test_wrong_password_deletes_the_profile_this_attempt_created(self, monkeypatch):
+        """The hardware repro (2026-08-08 20:12): a wrong PSK fails via
+        nmcli's own WRONG_KEY exit in ~24s and leaves the profile saved with
+        autoconnect=yes and the bad password. On a fielded device that
+        profile autoconnect-loops failed auth whenever the real network
+        drops — every retry on the single radio is time NOT rejoining the
+        good network. UUID-identified, so it holds even when NM uniquified
+        the name ("MyNet 1") because a same-named profile already existed."""
+        calls = self._patch(
+            monkeypatch,
+            returncode=1,
+            stderr="Error: Connection activation failed: Secrets were required, but not provided.",
+            connected=False,
+            uuids_before=("u-preexisting",),
+            uuids_created=("u-new",),
+        )
+        ok, err = wifi_provision.connect_to_wifi("HomeWiFi", "badpw")
+        assert (ok, err) == (False, "Incorrect WiFi password")
+        delete = next(c for c in calls if "delete" in c)
+        assert delete[delete.index("delete") + 1 :] == ["uuid", "u-new"]
+        # Snapshot ORDER is load-bearing (litclock-dev#609 testing specialist): the first
+        # UUID listing must precede the connect, or the snapshot would see
+        # the just-created profile and classify it pre-existing, disabling
+        # the entire cleanup.
+        first_show = next(i for i, c in enumerate(calls) if c == ["-t", "-f", "UUID", "connection", "show"])
+        connect = next(i for i, c in enumerate(calls) if "connect" in c)
+        assert first_show < connect, "pre-connect snapshot must be taken BEFORE the connect"
+
+    def test_wrong_password_with_a_reused_profile_deletes_nothing(self, monkeypatch):
+        """`nmcli device wifi connect` REUSES an existing profile for the
+        same SSID (under ANY name — the UUID diff makes the profile's name
+        irrelevant). Deleting on auth failure would destroy a previously-
+        working saved network — the hazard the owner declined to risk in
+        litclock-dev#600. Nothing new appeared, so nothing is deleted."""
+        calls = self._patch(
+            monkeypatch,
+            returncode=1,
+            stderr="Error: Connection activation failed: Secrets were required, but not provided.",
+            connected=False,
+            uuids_before=("u-home",),
+            uuids_created=(),
+        )
+        ok, _err = wifi_provision.connect_to_wifi("HomeWiFi", "badpw")
+        assert ok is False
+        assert not any("delete" in c for c in calls)
+
+    def test_success_never_deletes(self, monkeypatch):
+        """Mutation-hunting pin (litclock-dev#609 testing specialist): an unconditional
+        cleanup on the success path passed the whole suite before this test.
+        A successful join created a profile with a VERIFIED password —
+        deleting it would drop WiFi on the next disconnect or reboot."""
+        calls = self._patch(
+            monkeypatch,
+            returncode=0,
+            connected=True,
+            uuids_before=("u-old",),
+            uuids_created=("u-good",),
+        )
+        ok, err = wifi_provision.connect_to_wifi("HiddenNet", "pw", hidden=True)
+        assert (ok, err) == (True, None)
+        assert not any("delete" in c for c in calls)
+        assert ["device", "disconnect", "wlan0"] not in calls
+
+    def test_not_found_failure_also_cleans_up_a_created_profile(self, monkeypatch):
+        """The cleanup is failure-class-agnostic: any nmcli self-exit that
+        left a profile behind gets the same diff-based delete."""
+        calls = self._patch(
+            monkeypatch,
+            returncode=1,
+            stderr="Error: No network with SSID 'GhostNet' found.",
+            connected=False,
+            uuids_created=("u-ghost",),
+        )
+        ok, _err = wifi_provision.connect_to_wifi("GhostNet", "pw", hidden=True)
+        assert ok is False
+        assert any("delete" in c and "u-ghost" in c for c in calls)
+
+    def test_generic_failure_also_cleans_up_a_created_profile(self, monkeypatch):
+        """litclock-dev#609 testing specialist: hoisting the cleanup into only the auth
+        and not-found branches passed the whole suite — the fall-through
+        'Connection failed:' class (device busy, activation failed with any
+        other reason) must keep the same cleanup."""
+        calls = self._patch(
+            monkeypatch,
+            returncode=1,
+            stderr="Error: Connection activation failed: (53) The device is busy.",
+            connected=False,
+            uuids_created=("u-busy",),
+        )
+        ok, err = wifi_provision.connect_to_wifi("Net", "pw")
+        assert ok is False
+        assert err.startswith("Connection failed:")
+        assert any("delete" in c and "u-busy" in c for c in calls)
+
+    def test_wrong_password_delete_failure_is_logged(self, monkeypatch, caplog):
+        """The delete is the only thing standing between an auth failure and
+        the armed-profile class — its failure must not be silent, and the
+        user must still get the honest password copy."""
+        self._patch(
+            monkeypatch,
+            returncode=1,
+            stderr="Error: Connection activation failed: Secrets were required, but not provided.",
+            connected=False,
+            uuids_created=("u-n",),
+            delete_rc=1,
+        )
+        with caplog.at_level("ERROR"):
+            ok, err = wifi_provision.connect_to_wifi("HomeWiFi", "badpw")
+        assert (ok, err) == (False, "Incorrect WiFi password")
+        assert "Could not delete profile u-n" in caplog.text
+        assert "litclock-dev#595" in caplog.text
+
+    def test_wrong_password_with_unavailable_listing_skips_delete_and_warns(self, monkeypatch, caplog):
+        """litclock-dev#609 Codex: with the diff unavailable on a SELF-EXIT failure there
+        is no activation to abort, so a name-guessed delete has no upside to
+        weigh against deleting a good pre-existing profile. Skip, loudly."""
+        calls = self._patch(
+            monkeypatch,
+            returncode=1,
+            stderr="Error: Connection activation failed: Secrets were required, but not provided.",
+            connected=False,
+            uuids_show_rc=1,
+        )
+        with caplog.at_level("WARNING"):
+            ok, _err = wifi_provision.connect_to_wifi("HomeWiFi", "badpw")
+        assert ok is False
+        assert not any("delete" in c for c in calls)
+        assert "leaving profiles untouched" in caplog.text
+
+    def test_unbounded_cli_timeout_opts_out_of_cleanup(self, monkeypatch):
+        """litclock-dev#600 decision d: --timeout 0 is the SSH-recovery path, which must
+        never delete profiles — litclock-dev#595's cleanup keeps that
+        contract on every failure class, not just timeouts."""
+        calls = self._patch(
+            monkeypatch,
+            returncode=1,
+            stderr="Error: Connection activation failed: Secrets were required, but not provided.",
+            connected=False,
+            uuids_created=("u-n",),
+            expected_connect_timeout=None,
+        )
+        ok, _err = wifi_provision.connect_to_wifi("Net", "pw", connect_timeout=None)
+        assert ok is False
+        assert not any("delete" in c for c in calls)
+
+    def test_timeout_with_a_reused_profile_disconnects_and_deletes_nothing(self, monkeypatch):
+        """rc-124 with a reused profile: the activation must still be
+        aborted (the radio is needed for the hotspot restore) but nothing
+        new was created, so nothing is deleted — regardless of what the
+        reused profile is NAMED (litclock-dev#609: nmcli reuses by SSID match, and an
+        operator can rename a profile over SSH)."""
+        calls = self._patch(
+            monkeypatch,
+            returncode=wifi_provision.NMCLI_TIMEOUT_RC,
+            stderr="nmcli timed out",
+            connected=False,
+            uuids_before=("u-renamed",),
+            uuids_created=(),
+        )
+        ok, err = wifi_provision.connect_to_wifi("HiddenNet", "pw", hidden=True)
+        assert ok is False
+        assert "didn't answer in time" in err
+        assert not any("delete" in c for c in calls)
+        assert ["device", "disconnect", "wlan0"] in calls
+
+    def test_timeout_disconnect_failure_is_logged_and_delete_still_runs(self, monkeypatch, caplog):
+        """The abort and the cleanup are independent halves — a failed
+        disconnect must be loud (the activation is racing the hotspot
+        restore) and must not skip the armed-profile delete."""
+        calls = self._patch(
+            monkeypatch,
+            returncode=wifi_provision.NMCLI_TIMEOUT_RC,
+            stderr="nmcli timed out",
+            connected=False,
+            uuids_created=("u-n",),
+            disconnect_rc=1,
+        )
+        with caplog.at_level("ERROR"):
+            ok, _err = wifi_provision.connect_to_wifi("HiddenNet", "pw", hidden=True)
+        assert ok is False
+        assert "may still be racing the hotspot restore" in caplog.text
+        assert any("delete" in c and "u-n" in c for c in calls)
+
+    def test_timeout_falls_back_to_name_delete_when_the_diff_is_unavailable(self, monkeypatch):
+        """A listing hiccup must not leave the armed profile: on the timeout
+        path the attempt got far enough to activate, so a leftover is
+        near-certain — fall back to litclock-dev#600's shipped name-targeted delete
+        (explicit `id` selector). The device abort above already handled
+        the racing-activation half."""
+        calls = self._patch(
+            monkeypatch,
+            returncode=wifi_provision.NMCLI_TIMEOUT_RC,
+            stderr="nmcli timed out",
+            connected=False,
+            uuids_show_rc=1,
+        )
+        ok, _err = wifi_provision.connect_to_wifi("HiddenNet", "pw", hidden=True)
+        assert ok is False
+        assert ["device", "disconnect", "wlan0"] in calls
+        delete = next(c for c in calls if "delete" in c)
+        assert delete[delete.index("delete") + 1 :] == ["id", "HiddenNet"]
+
+
+class TestPskRestore:
+    """litclock-dev#613 (hardware-verified 2026-08-09, NM 1.42.4): a failed
+    ``nmcli device wifi connect`` on an SSID with a PRE-EXISTING saved
+    profile REUSES that profile and persists the attempted (wrong) password
+    into it — same UUID, no new profile, so the litclock-dev#609 UUID set-diff cleanup
+    is structurally blind. A previously-working saved network is left armed
+    with a password that can never authenticate. connect_to_wifi now
+    snapshots the stored PSK of matching pre-existing profiles before the
+    attempt and restores it on the failure paths where nmcli reported the
+    connect itself failed (NOT the rc=0 no-IP path — association there proves
+    the submitted password was right).
+
+    The fake mirrors the hardware behavior: the connect call rewrites the
+    matching profile's stored PSK to the attempted password. It also serves
+    the ``UUID,TYPE`` snapshot listing + per-profile ssid reads, terse-mode
+    escaping the ssid field so the escaped-colon path is exercised."""
+
+    GOOD = "correct-horse"
+    SNAPSHOT_LISTING = ["-t", "-f", "UUID,TYPE", "connection", "show"]
+
+    @staticmethod
+    def _terse(value):
+        """nmcli -t escapes ``\\`` and the ``:`` separator in value fields."""
+        return value.replace("\\", "\\\\").replace(":", "\\:")
+
+    def _patch(
+        self,
+        monkeypatch,
+        *,
+        profiles=None,
+        connect_rc=1,
+        connect_stderr="Error: Connection activation failed: Secrets were required, but not provided.",
+        connected=False,
+        listing_rc=0,
+        connect_rewrites=True,
+        connect_deletes=False,
+        modify_rc=0,
+        psk_read_rc=0,
+    ):
+        """``profiles``: uuid -> {"ssid": ..., "psk": ...} saved wifi profiles
+        (a non-wifi ``u-eth`` entry is always present in the listing so the
+        type filter is exercised). The connect call mutates the matching
+        profile's psk (``connect_rewrites``) or removes the profile entirely
+        (``connect_deletes`` — the vanished-before-restore race). ``psk_read_rc``
+        != 0 fails every secret read (snapshot degradation path)."""
+        profiles = {} if profiles is None else {u: dict(p) for u, p in profiles.items()}
+        calls: list[list[str]] = []
+
+        def fake_run(args, check=True, sudo=False, timeout=None, secret_output=False, input_text=None):
+            calls.append(list(args))
+            # The litclock-dev#599 invariant, enforced at the fake on EVERY
+            # dispatch: no secret VALUE may appear in any argv token (sudo
+            # audits argv to persistent journald), and the write-form
+            # `password` key must never be present. Property NAMES in read
+            # argvs (-s -g 802-11-wireless-security.psk) are fine — they
+            # introduce no value.
+            for _sec in [prof["psk"] for prof in profiles.values()]:
+                assert not (_sec and any(_sec in tok for tok in args)), f"secret value in argv: {args}"
+            assert "password" not in args, f"password key in argv: {args}"
+            if args == ["-t", "-f", "UUID", "connection", "show"]:
+                return SimpleNamespace(returncode=0, stdout="".join(f"{u}\n" for u in profiles), stderr="")
+            if args[:2] == ["-t", "-f"] and args[3:] == ["connection", "show"]:
+                # Real nmcli 1.42.4: the LIST form accepts only profile
+                # COLUMNS; a setting property (contains a dot) is rc=2
+                # "invalid field". The old fake accepted the dotted field,
+                # which hid that the litclock-dev#616 one-listing snapshot NEVER worked
+                # on hardware (litclock-dev#630 retest).
+                if "." in args[2]:
+                    return SimpleNamespace(returncode=2, stdout="", stderr="Error: invalid field")
+                if listing_rc:
+                    return SimpleNamespace(returncode=listing_rc, stdout="", stderr="cannot list")
+                body = "".join(f"{u}:802-11-wireless\n" for u in profiles)
+                return SimpleNamespace(returncode=0, stdout=body + "u-eth:802-3-ethernet\n", stderr="")
+            if args[:3] == ["-t", "-g", "802-11-wireless.ssid"]:
+                uuid = args[-1]
+                if uuid not in profiles:
+                    return SimpleNamespace(returncode=10, stdout="", stderr="unknown")
+                return SimpleNamespace(returncode=0, stdout=self._terse(profiles[uuid]["ssid"]) + "\n", stderr="")
+            if args[:3] == ["-s", "-g", "802-11-wireless-security.psk"]:
+                uuid = args[-1]
+                if psk_read_rc or uuid not in profiles:
+                    return SimpleNamespace(returncode=psk_read_rc or 10, stdout="", stderr="unreadable")
+                # -g output is terse-ESCAPED even for one field (verified on
+                # NM 1.42.4) — the fake mirrors that so the production
+                # unescape is exercised, not optional (litclock-dev#599 F1).
+                return SimpleNamespace(returncode=0, stdout=self._terse(profiles[uuid]["psk"]) + "\n", stderr="")
+            if args[:3] == ["connection", "edit", "uuid"]:
+                # litclock-dev#599: the restore write arrives as editor
+                # commands on stdin, never as argv. Mirror the editor: `set`
+                # writes the value, `remove` clears it; a failing editor
+                # (modify_rc) changes nothing — the read-back verify is what
+                # must catch that.
+                uuid = args[3]
+                assert input_text and input_text.endswith("quit\n"), "editor script must end with quit"
+                if modify_rc == 0 and uuid in profiles:
+                    m = re.search(r"^set 802-11-wireless-security\.psk (.*)$", input_text, re.M)
+                    if m:
+                        profiles[uuid]["psk"] = m.group(1)
+                    elif "remove 802-11-wireless-security.psk" in input_text:
+                        profiles[uuid]["psk"] = ""
+                return SimpleNamespace(returncode=modify_rc, stdout="", stderr="")
+            if "connect" in args:
+                target = args[args.index("connect") + 1]
+                # The attempted password arrives as the first stdin line
+                # under --ask (litclock-dev#599) — never via argv or a file.
+                if "--ask" in args:
+                    assert input_text and input_text.endswith("\n"), "--ask needs a newline-terminated stdin secret"
+                    attempted = input_text.splitlines()[0]
+                else:
+                    attempted = ""  # open network — no secrets channel at all
+                for uuid in list(profiles):
+                    if profiles[uuid]["ssid"] == target:
+                        if connect_deletes:
+                            del profiles[uuid]
+                        elif connect_rewrites and attempted:
+                            profiles[uuid]["psk"] = attempted
+                return SimpleNamespace(returncode=connect_rc, stdout="", stderr=connect_stderr)
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(wifi_provision, "_run_nmcli", fake_run)
+        monkeypatch.setattr(wifi_provision, "is_wifi_connected", lambda: connected)
+        monkeypatch.setattr(wifi_provision, "get_wifi_ssid", lambda: "")
+        monkeypatch.setattr(wifi_provision, "_clear_wifi_watchdog_counter", lambda: None)
+        monkeypatch.setattr(wifi_provision.time, "sleep", lambda _s: None)
+        return calls, profiles
+
+    def _modifies(self, calls):
+        return [c for c in calls if c[:3] == ["connection", "edit", "uuid"]]
+
+    def test_wrong_password_restores_the_saved_psk(self, monkeypatch):
+        """The hardware repro, end-to-end: reused profile's stored PSK is
+        the wrong password after the failed connect; the restore puts the
+        good one back, by UUID, via editor commands on stdin — never a
+        wifi-sec.psk argv token (litclock-dev#599)."""
+        calls, profiles = self._patch(
+            monkeypatch,
+            profiles={
+                "u-good": {"ssid": "HomeWiFi", "psk": self.GOOD},
+                "u-other": {"ssid": "SomewhereElse", "psk": "unrelated"},
+            },
+        )
+        ok, err = wifi_provision.connect_to_wifi("HomeWiFi", "WRONGWRONG")
+        assert ok is False
+        assert "Incorrect WiFi password" in err
+        assert profiles["u-good"]["psk"] == self.GOOD, "the failed attempt's password must be un-written"
+        assert profiles["u-other"]["psk"] == "unrelated"
+        modifies = self._modifies(calls)
+        assert modifies == [["connection", "edit", "uuid", "u-good"]]
+
+    def test_unchanged_psk_is_left_alone(self, monkeypatch):
+        """If NM didn't rewrite the profile, no modify is issued — the
+        restore must be conditional, not unconditional churn."""
+        calls, profiles = self._patch(
+            monkeypatch,
+            profiles={"u-good": {"ssid": "HomeWiFi", "psk": self.GOOD}},
+            connect_rewrites=False,
+        )
+        ok, _err = wifi_provision.connect_to_wifi("HomeWiFi", "WRONGWRONG")
+        assert ok is False
+        assert self._modifies(calls) == []
+
+    def test_timeout_path_restores_after_abort(self, monkeypatch):
+        """The bounded-connect branch must restore too — and only after the
+        activation abort, so the modify can't race the in-flight join."""
+        calls, profiles = self._patch(
+            monkeypatch,
+            profiles={"u-good": {"ssid": "HomeWiFi", "psk": self.GOOD}},
+            connect_rc=wifi_provision.NMCLI_TIMEOUT_RC,
+            connect_stderr="nmcli timed out",
+        )
+        ok, err = wifi_provision.connect_to_wifi("HomeWiFi", "WRONGWRONG")
+        assert ok is False
+        assert "didn't answer in time" in err
+        assert profiles["u-good"]["psk"] == self.GOOD
+        modifies = self._modifies(calls)
+        assert len(modifies) == 1
+        assert calls.index(["device", "disconnect", "wlan0"]) < calls.index(modifies[0])
+
+    def test_manual_timeout_none_never_snapshots_or_restores(self, monkeypatch):
+        """litclock-dev#600 decision d: the SSH-recovery path (--timeout 0 →
+        connect_timeout=None) must never touch profiles — that now includes
+        never READING their secrets either."""
+        calls, _profiles = self._patch(
+            monkeypatch,
+            profiles={"u-good": {"ssid": "HomeWiFi", "psk": self.GOOD}},
+        )
+        ok, _err = wifi_provision.connect_to_wifi("HomeWiFi", "WRONGWRONG", connect_timeout=None)
+        assert ok is False
+        assert self.SNAPSHOT_LISTING not in calls
+        assert self._modifies(calls) == []
+
+    def test_listing_failure_degrades_to_noop(self, monkeypatch):
+        """Snapshot unavailable → restore is a no-op, the failure still
+        returns normally — degraded observability, never a new crash."""
+        calls, _profiles = self._patch(
+            monkeypatch,
+            profiles={"u-good": {"ssid": "HomeWiFi", "psk": self.GOOD}},
+            listing_rc=1,
+        )
+        ok, err = wifi_provision.connect_to_wifi("HomeWiFi", "WRONGWRONG")
+        assert ok is False
+        assert "Incorrect WiFi password" in err
+        assert self._modifies(calls) == []
+
+    def test_success_keeps_the_newly_written_psk(self, monkeypatch):
+        """On success NM stored the password that actually authenticated —
+        restoring the old one would be wrong. No modify on the happy path."""
+        calls, profiles = self._patch(
+            monkeypatch,
+            profiles={"u-good": {"ssid": "HomeWiFi", "psk": "old-rotated-away"}},
+            connect_rc=0,
+            connect_stderr="",
+            connected=True,
+        )
+        ok, err = wifi_provision.connect_to_wifi("HomeWiFi", self.GOOD)
+        assert (ok, err) == (True, None)
+        assert profiles["u-good"]["psk"] == self.GOOD
+        assert self._modifies(calls) == []
+
+    def test_profile_vanished_before_restore_is_skipped(self, monkeypatch):
+        """A profile deleted between snapshot and restore (e.g. by cleanup
+        or an operator) is skipped — unreadable current PSK must not crash
+        or spray modifies at dead UUIDs."""
+        calls, _profiles = self._patch(
+            monkeypatch,
+            profiles={"u-good": {"ssid": "HomeWiFi", "psk": self.GOOD}},
+            connect_deletes=True,
+        )
+        ok, _err = wifi_provision.connect_to_wifi("HomeWiFi", "WRONGWRONG")
+        assert ok is False
+        assert self._modifies(calls) == []
+
+    def test_modify_failure_is_logged_loudly(self, monkeypatch, caplog):
+        """A failed restore leaves the device unable to rejoin — that must
+        reach the journal as an ERROR naming the consequence, never pass
+        silently (the silent-swallow class)."""
+        _calls, _profiles = self._patch(
+            monkeypatch,
+            profiles={"u-good": {"ssid": "HomeWiFi", "psk": self.GOOD}},
+            modify_rc=4,
+        )
+        with caplog.at_level("ERROR"):
+            ok, _err = wifi_provision.connect_to_wifi("HomeWiFi", "WRONGWRONG")
+        assert ok is False
+        assert "Could not restore the saved password" in caplog.text
+        assert self.GOOD not in caplog.text, "the secret must never reach logs"
+
+    def test_third_party_change_between_snapshot_and_failure_is_not_clobbered(self, monkeypatch):
+        """litclock-dev#616 review (Codex): restore keys on ``current == attempted``, not
+        ``current != good``. If something other than this attempt set the PSK
+        (SSH, a concurrent NM edit) to a THIRD value, the restore must leave
+        it alone rather than roll it back to the stale snapshot."""
+        calls, profiles = self._patch(
+            monkeypatch,
+            profiles={"u-good": {"ssid": "HomeWiFi", "psk": self.GOOD}},
+            connect_rewrites=False,  # this attempt did NOT write the profile
+        )
+        profiles["u-good"]["psk"] = "changed-by-someone-else"  # a third value
+        ok, _err = wifi_provision.connect_to_wifi("HomeWiFi", "WRONGWRONG")
+        assert ok is False
+        assert self._modifies(calls) == []
+        assert profiles["u-good"]["psk"] == "changed-by-someone-else"
+
+    def test_open_network_empty_psk_is_never_modified(self, monkeypatch):
+        """An open network has an empty stored PSK; the attempt password is
+        also empty, so there is nothing this attempt could have corrupted —
+        no modify (attempted == good == '')."""
+        calls, _profiles = self._patch(
+            monkeypatch,
+            profiles={"u-open": {"ssid": "CafeWiFi", "psk": ""}},
+        )
+        ok, _err = wifi_provision.connect_to_wifi("CafeWiFi", "")
+        assert ok is False
+        assert self._modifies(calls) == []
+
+    def test_colon_and_backslash_psk_round_trips_through_escaping(self, monkeypatch):
+        """litclock-dev#599 review F1 (hardware-verified on NM 1.42.4): -g
+        terse-escapes the VALUE even for one field, and the editor's `set`
+        takes the raw value literally. Without unescaping the three psk
+        reads, a good PSK containing ':' or a backslash is (a) never matched
+        for restore when the ATTEMPT contains one, and (b) written back in
+        escaped form — corrupted to a third value."""
+        tricky_good = "pa:ss\\word99"
+        calls, profiles = self._patch(
+            monkeypatch,
+            profiles={"u-good": {"ssid": "HomeWiFi", "psk": tricky_good}},
+        )
+        ok, _err = wifi_provision.connect_to_wifi("HomeWiFi", "also:wro\\ng1")
+        assert ok is False
+        assert profiles["u-good"]["psk"] == tricky_good, "raw value must round-trip unmangled"
+        assert self._modifies(calls) == [["connection", "edit", "uuid", "u-good"]]
+
+    def test_control_char_snapshot_psk_skips_restore_loudly(self, monkeypatch, caplog):
+        """A snapshot value with a newline would execute as editor commands
+        under sudo; the restore must refuse it with an ERROR, never feed it
+        to the editor (litclock-dev#599 review F3)."""
+        calls, profiles = self._patch(
+            monkeypatch,
+            profiles={"u-good": {"ssid": "HomeWiFi", "psk": "bad\npsk99"}},
+        )
+        with caplog.at_level("ERROR"):
+            ok, _err = wifi_provision.connect_to_wifi("HomeWiFi", "WRONGWRONG")
+        assert ok is False
+        assert self._modifies(calls) == []
+        assert "cannot carry safely" in caplog.text
+        assert "bad" + chr(10) + "psk99" not in caplog.text, "the secret must never reach logs"
+
+    def test_colon_in_ssid_still_matches_and_restores(self, monkeypatch):
+        """litclock-dev#616 review F8: nmcli terse-mode escapes ':' in the ssid field
+        (``My\\:Net``). The single-listing parse must un-escape it or a
+        colon-SSID profile silently misses the snapshot and never restores."""
+        calls, profiles = self._patch(
+            monkeypatch,
+            profiles={"u-good": {"ssid": "My:Net", "psk": self.GOOD}},
+        )
+        ok, _err = wifi_provision.connect_to_wifi("My:Net", "WRONGWRONG")
+        assert ok is False
+        assert profiles["u-good"]["psk"] == self.GOOD
+        assert self._modifies(calls) == [["connection", "edit", "uuid", "u-good"]]
+
+    def test_snapshot_uses_one_listing_not_per_profile_queries(self, monkeypatch):
+        """litclock-dev#616 review F1: the snapshot must be O(1) nmcli listings + one
+        secret read per match, NOT a per-profile ssid query (the N+1 that
+        could serialize many 10s timeouts before the connect started)."""
+        calls, _profiles = self._patch(
+            monkeypatch,
+            profiles={
+                "u-a": {"ssid": "A", "psk": "pa"},
+                "u-b": {"ssid": "B", "psk": "pb"},
+                "u-c": {"ssid": "HomeWiFi", "psk": self.GOOD},
+            },
+        )
+        wifi_provision.connect_to_wifi("HomeWiFi", "WRONGWRONG")
+        # Exactly one UUID,TYPE listing. The ssid comes from per-WIFI-profile
+        # unprivileged reads (the litclock-dev#616 one-listing dotted field is rc=2 on
+        # real nmcli — the fake now rejects it too), and the SUDO SECRET
+        # reads stay per-MATCH: that is the litclock-dev#616-F1 contract that matters.
+        assert calls.count(self.SNAPSHOT_LISTING) == 1
+        ssid_reads = [c for c in calls if c[:3] == ["-t", "-g", "802-11-wireless.ssid"]]
+        assert {c[-1] for c in ssid_reads} == {"u-a", "u-b", "u-c"}, "one ssid read per WIFI profile"
+        # Secret reads only for the match (u-c): snapshot + restore pre-write
+        # re-read + post-edit verify read-back (litclock-dev#599) = u-c only.
+        psk_reads = [c for c in calls if c[:3] == ["-s", "-g", "802-11-wireless-security.psk"]]
+        assert psk_reads and all(c[-1] == "u-c" for c in psk_reads), psk_reads
+
+    def test_snapshot_listing_failure_logs_a_warning(self, monkeypatch, caplog):
+        """litclock-dev#616 review F6: a snapshot that can't list must WARN, not fail
+        silently — a silent miss leaves the litclock-dev#613 brick state with no trace."""
+        self._patch(
+            monkeypatch,
+            profiles={"u-good": {"ssid": "HomeWiFi", "psk": self.GOOD}},
+            listing_rc=1,
+        )
+        with caplog.at_level("WARNING"):
+            wifi_provision.connect_to_wifi("HomeWiFi", "WRONGWRONG")
+        assert "will NOT be auto-restored" in caplog.text
+
+    def test_snapshot_secret_read_failure_logs_a_warning(self, monkeypatch, caplog):
+        """litclock-dev#616 review F6: an unreadable secret at snapshot time also WARNs
+        (UUID only, never the value)."""
+        self._patch(
+            monkeypatch,
+            profiles={"u-good": {"ssid": "HomeWiFi", "psk": self.GOOD}},
+            psk_read_rc=5,
+        )
+        with caplog.at_level("WARNING"):
+            wifi_provision.connect_to_wifi("HomeWiFi", "WRONGWRONG")
+        assert "Could not read the saved password" in caplog.text
+        assert self.GOOD not in caplog.text
+
+
+class TestNoSecretInArgv:
+    """The litclock-dev#599 end-to-end invariant, enforced at the subprocess
+    boundary: across a full failed connect INCLUDING the litclock-dev#613 PSK restore,
+    neither the attempted password nor the restored good PSK may appear in any
+    argv — sudo's command audit writes argv to persistent journald, which is
+    exactly how both leaked before this redesign (hardware-verified, including
+    a real home PSK)."""
+
+    GOOD = "good-secret-psk"
+    ATTEMPTED = "attempted-secret"
+
+    def test_connect_and_restore_argv_never_carry_secrets(self, monkeypatch):
+        argvs = []
+        stored = {"psk": self.GOOD}
+
+        def fake_subprocess_run(cmd, capture_output=True, text=True, timeout=None, input=None):
+            argvs.append(list(cmd))
+            args = list(cmd[cmd.index("nmcli") + 1 :])
+            if args == ["-t", "-f", "UUID", "connection", "show"]:
+                return subprocess.CompletedProcess(cmd, 0, "u-1\n", "")
+            if args == ["-t", "-f", "UUID,TYPE", "connection", "show"]:
+                return subprocess.CompletedProcess(cmd, 0, "u-1:802-11-wireless\n", "")
+            if args[:3] == ["-t", "-g", "802-11-wireless.ssid"]:
+                return subprocess.CompletedProcess(cmd, 0, "HomeWiFi\n", "")
+            if args[:3] == ["-s", "-g", "802-11-wireless-security.psk"]:
+                escaped = stored["psk"].replace("\\", "\\\\").replace(":", "\\:")
+                return subprocess.CompletedProcess(cmd, 0, escaped + "\n", "")
+            if "connect" in args:
+                assert "--ask" in args and input == self.ATTEMPTED + "\n", "secret must arrive via --ask stdin"
+                stored["psk"] = self.ATTEMPTED  # NM persists the attempt (litclock-dev#613)
+                return subprocess.CompletedProcess(cmd, 1, "", "Secrets were required, but not provided.")
+            if args[:3] == ["connection", "edit", "uuid"]:
+                if input and f"set 802-11-wireless-security.psk {self.GOOD}" in input:
+                    stored["psk"] = self.GOOD
+                return subprocess.CompletedProcess(cmd, 0, "", "")
+            return subprocess.CompletedProcess(cmd, 0, "", "")
+
+        monkeypatch.setattr(wifi_provision.subprocess, "run", fake_subprocess_run)
+        monkeypatch.setattr(wifi_provision, "is_wifi_connected", lambda: False)
+        monkeypatch.setattr(wifi_provision, "get_wifi_ssid", lambda: "")
+        monkeypatch.setattr(wifi_provision, "_clear_wifi_watchdog_counter", lambda: None)
+        monkeypatch.setattr(wifi_provision.time, "sleep", lambda _s: None)
+
+        ok, err = wifi_provision.connect_to_wifi("HomeWiFi", self.ATTEMPTED)
+        assert ok is False and "Incorrect WiFi password" in err
+        for secret in (self.GOOD, self.ATTEMPTED):
+            leaked = [v for v in argvs if any(secret in token for token in v)]
+            assert not leaked, f"secret reached argv: {leaked}"
+        # Anti-vacuity: the mechanisms this invariant protects actually ran.
+        assert any("--ask" in v for v in argvs), "connect must use --ask"
+        assert stored["psk"] == self.GOOD, "the restore must have completed via the editor stdin"
+
+    def test_open_network_connect_omits_the_passwd_file(self, monkeypatch):
+        argvs = []
+
+        def fake_subprocess_run(cmd, capture_output=True, text=True, timeout=None, input=None):
+            argvs.append(list(cmd))
+            return subprocess.CompletedProcess(cmd, 0, "", "")
+
+        monkeypatch.setattr(wifi_provision.subprocess, "run", fake_subprocess_run)
+        monkeypatch.setattr(wifi_provision, "is_wifi_connected", lambda: True)
+        monkeypatch.setattr(wifi_provision, "get_wifi_ssid", lambda: "CafeWiFi")
+        monkeypatch.setattr(wifi_provision, "_clear_wifi_watchdog_counter", lambda: None)
+        monkeypatch.setattr(wifi_provision.time, "sleep", lambda _s: None)
+
+        ok, _err = wifi_provision.connect_to_wifi("CafeWiFi", "")
+        assert ok is True
+        connect = next(v for v in argvs if "connect" in v)
+        assert "--ask" not in connect and "password" not in connect
+
+    def test_control_char_password_rejected_before_any_nmcli(self, monkeypatch):
+        # A newline in the password would be consumed as an extra --ask prompt
+        # line (and can't exist in a real WPA passphrase); it must fail fast
+        # with the honest class and ZERO subprocess activity.
+        def must_not_run(*a, **k):
+            raise AssertionError("no subprocess may run for a control-char password")
+
+        monkeypatch.setattr(wifi_provision.subprocess, "run", must_not_run)
+        ok, err = wifi_provision.connect_to_wifi("HomeWiFi", "pass\nword1")
+        assert ok is False
+        assert err.failure_class == wifi_provision.WIFI_FAIL_BAD_PASSWORD
+        assert "control characters" in err
+
+
+class TestUnescapeTerse:
+    """nmcli -t escaping round-trip (litclock-dev#613/litclock-dev#616 F8)."""
+
+    def test_plain_value_untouched(self):
+        assert wifi_provision._unescape_terse("HomeWiFi") == "HomeWiFi"
+
+    def test_escaped_colon(self):
+        assert wifi_provision._unescape_terse("My\\:Net") == "My:Net"
+
+    def test_escaped_backslash(self):
+        assert wifi_provision._unescape_terse("A\\\\B") == "A\\B"
+
+    def test_trailing_lone_backslash_kept(self):
+        assert wifi_provision._unescape_terse("odd\\") == "odd\\"
+
+
+class TestRunNmcliSecretOutput:
+    """litclock-dev#613/litclock-dev#616: a `-s -g …psk` read's STDOUT is the secret;
+    argv redaction does not cover output, so the TimeoutExpired branch must
+    not journal the partial pre-kill bytes for a secret_output command."""
+
+    def test_timeout_redacts_secret_output(self, monkeypatch, caplog):
+        def boom(*a, **k):
+            raise subprocess.TimeoutExpired(cmd="nmcli", timeout=10, output="hunter2-the-psk", stderr="")
+
+        monkeypatch.setattr(subprocess, "run", boom)
+        with caplog.at_level("ERROR"):
+            wifi_provision._run_nmcli(
+                ["-s", "-g", "802-11-wireless-security.psk", "connection", "show", "uuid", "u"],
+                check=False,
+                sudo=True,
+                timeout=10,
+                secret_output=True,
+            )
+        assert "hunter2-the-psk" not in caplog.text
+        assert "bytes redacted" in caplog.text
+
+    def test_timeout_keeps_output_for_non_secret_commands(self, monkeypatch, caplog):
+        def boom(*a, **k):
+            raise subprocess.TimeoutExpired(cmd="nmcli", timeout=30, output="Connecting (prepare)", stderr="")
+
+        monkeypatch.setattr(subprocess, "run", boom)
+        with caplog.at_level("ERROR"):
+            wifi_provision._run_nmcli(["device", "wifi", "connect", "Home"], check=False, sudo=True, timeout=30)
+        assert "Connecting (prepare)" in caplog.text
+
 
 class TestNmcliSecretRedaction:
     """The connect argv carries the recipient's home WiFi PSK in the clear.
@@ -472,6 +1331,21 @@ class TestNmcliSecretRedaction:
     def test_trailing_password_key_does_not_crash(self):
         assert wifi_provision._redact_nmcli(["nmcli", "password"]) == ["nmcli", "password"]
 
+    def test_returned_result_argv_is_redacted_on_the_common_path(self, monkeypatch):
+        """The non-timeout result comes straight from subprocess.run, which
+        stores the RAW argv in .args — without the overwrite in _run_nmcli
+        the safe-to-log property would hold only for the rare timeout
+        sentinel, not the shape every caller actually receives (/review on
+        litclock-dev#606)."""
+        monkeypatch.setattr(
+            subprocess,
+            "run",
+            lambda cmd, **k: subprocess.CompletedProcess(cmd, 0, stdout="ok", stderr=""),
+        )
+        result = wifi_provision._run_nmcli(["device", "wifi", "connect", "Home", "password", "s3cret"])
+        assert "s3cret" not in " ".join(result.args)
+        assert "***" in result.args
+
     def test_the_debug_line_itself_is_redacted(self, monkeypatch, caplog):
         """The unit above is only useful if _run_nmcli actually calls it."""
         monkeypatch.setattr(subprocess, "run", lambda *a, **k: SimpleNamespace(returncode=0, stdout="", stderr=""))
@@ -479,6 +1353,42 @@ class TestNmcliSecretRedaction:
             wifi_provision._run_nmcli(["device", "wifi", "connect", "Home", "password", "s3cret"], sudo=True)
         assert "s3cret" not in caplog.text
         assert "***" in caplog.text
+
+
+class TestProfileUuids:
+    """litclock-dev#595 — the snapshot half of snapshot-and-diff."""
+
+    def test_uuids_are_parsed_and_stripped(self, monkeypatch):
+        monkeypatch.setattr(
+            wifi_provision,
+            "_run_nmcli",
+            lambda *a, **k: SimpleNamespace(returncode=0, stdout="u-aaa\nu-bbb\n\n", stderr=""),
+        )
+        assert wifi_provision._profile_uuids() == {"u-aaa", "u-bbb"}
+
+    def test_listing_failure_returns_none_not_empty(self, monkeypatch):
+        """None (unknown) and set() (known-empty) drive different cleanup
+        decisions — a failed listing must not masquerade as an empty one."""
+        monkeypatch.setattr(
+            wifi_provision,
+            "_run_nmcli",
+            lambda *a, **k: SimpleNamespace(returncode=1, stdout="", stderr="boom"),
+        )
+        assert wifi_provision._profile_uuids() is None
+
+    def test_created_diff_is_none_when_either_side_is_unknown(self, monkeypatch):
+        monkeypatch.setattr(
+            wifi_provision,
+            "_run_nmcli",
+            lambda *a, **k: SimpleNamespace(returncode=0, stdout="u-a\n", stderr=""),
+        )
+        assert wifi_provision._created_profile_uuids(None) is None
+        monkeypatch.setattr(
+            wifi_provision,
+            "_run_nmcli",
+            lambda *a, **k: SimpleNamespace(returncode=1, stdout="", stderr="boom"),
+        )
+        assert wifi_provision._created_profile_uuids({"u-a"}) is None
 
 
 class TestRunNmcliTimeout:
@@ -491,6 +1401,17 @@ class TestRunNmcliTimeout:
     @staticmethod
     def _raise_timeout(cmd, **kwargs):
         raise subprocess.TimeoutExpired(cmd, kwargs.get("timeout"))
+
+    def test_synthetic_result_argv_is_redacted(self, monkeypatch):
+        """litclock-dev#605 item 9: the sentinel CompletedProcess embeds the
+        argv in .args — with the raw command that includes the PSK. Nothing
+        logs it today; make it safe to log by construction."""
+        monkeypatch.setattr(subprocess, "run", self._raise_timeout)
+        result = wifi_provision._run_nmcli(
+            ["device", "wifi", "connect", "Home", "password", "s3cret"], check=False, timeout=30
+        )
+        assert "s3cret" not in " ".join(result.args)
+        assert "***" in result.args
 
     def test_timeout_becomes_synthetic_completed_process(self, monkeypatch):
         monkeypatch.setattr(subprocess, "run", self._raise_timeout)
@@ -526,3 +1447,76 @@ class TestRunNmcliTimeout:
         with caplog.at_level("ERROR"):
             wifi_provision._run_nmcli(["device", "wifi", "connect", "Net", "password", "pw"], timeout=30)
         assert "Device activation was stalled" in caplog.text
+
+
+class TestWifiFailureClasses:
+    """litclock-dev#603 — connect_to_wifi's error carries its failure class
+    so the retry surfaces (e-ink variant, banner advice) branch on data
+    instead of re-deriving the cause from user-facing copy (the antipattern
+    litclock-dev#605 item 11 flags)."""
+
+    def _connect(self, monkeypatch, returncode, stderr, connected=False):
+        def fake_run(args, check=True, sudo=False, timeout=None, **_kw):
+            return SimpleNamespace(returncode=returncode, stdout="", stderr=stderr)
+
+        monkeypatch.setattr(wifi_provision, "_run_nmcli", fake_run)
+        monkeypatch.setattr(wifi_provision, "is_wifi_connected", lambda: connected)
+        monkeypatch.setattr(wifi_provision, "get_wifi_ssid", lambda: "Net")
+        monkeypatch.setattr(wifi_provision, "_clear_wifi_watchdog_counter", lambda: None)
+        monkeypatch.setattr(wifi_provision.time, "sleep", lambda _s: None)
+        return wifi_provision.connect_to_wifi("Net", "pw", hidden=True)
+
+    @pytest.mark.parametrize(
+        ("rc", "stderr", "expected"),
+        [
+            (wifi_provision.NMCLI_TIMEOUT_RC, "nmcli timed out", wifi_provision.WIFI_FAIL_TIMEOUT),
+            (
+                1,
+                "Error: Connection activation failed: Secrets were required, but not provided.",
+                wifi_provision.WIFI_FAIL_BAD_PASSWORD,
+            ),
+            (1, "Error: No network with SSID 'Net' found.", wifi_provision.WIFI_FAIL_NOT_FOUND),
+            (
+                1,
+                "Error: Connection activation failed: (53) The device is busy.",
+                wifi_provision.WIFI_FAIL_OTHER,
+            ),
+        ],
+        ids=["timeout", "bad-password", "not-found", "other"],
+    )
+    def test_failure_class_per_branch(self, monkeypatch, rc, stderr, expected):
+        ok, err = self._connect(monkeypatch, rc, stderr)
+        assert ok is False
+        assert err.failure_class == expected
+
+    def test_no_ip_failure_class(self, monkeypatch):
+        # rc 0 (nmcli succeeded) but the IP wait never sees a connection.
+        ok, err = self._connect(monkeypatch, 0, "", connected=False)
+        assert ok is False
+        assert err.failure_class == wifi_provision.WIFI_FAIL_NO_IP
+
+    def test_scanned_not_found_shares_the_not_found_class(self, monkeypatch):
+        def fake_run(args, check=True, sudo=False, timeout=None, **_kw):
+            return SimpleNamespace(returncode=1, stdout="", stderr="Error: No network with SSID 'Home' found.")
+
+        monkeypatch.setattr(wifi_provision, "_run_nmcli", fake_run)
+        monkeypatch.setattr(wifi_provision, "is_wifi_connected", lambda: False)
+        monkeypatch.setattr(wifi_provision.time, "sleep", lambda _s: None)
+        ok, err = wifi_provision.connect_to_wifi("Home", "pw", hidden=False)
+        assert ok is False
+        assert err.failure_class == wifi_provision.WIFI_FAIL_NOT_FOUND
+
+    def test_error_is_still_a_plain_string_to_every_consumer(self, monkeypatch):
+        """Every existing consumer treats the error as a str — html.escape
+        at the banner, equality asserts, substring checks, journald
+        interpolation. The class must ride along invisibly."""
+        import html as _html
+
+        ok, err = self._connect(
+            monkeypatch, 1, "Error: Connection activation failed: Secrets were required, but not provided."
+        )
+        assert ok is False
+        assert err == "Incorrect WiFi password"
+        assert isinstance(err, str)
+        assert _html.escape(err) == "Incorrect WiFi password"
+        assert f"{err}" == "Incorrect WiFi password"

--- a/tests/test_wifi_retry_flow.py
+++ b/tests/test_wifi_retry_flow.py
@@ -119,6 +119,49 @@ class TestWiFiBanners:
         banner_region = html[banner_start:banner_end]
         assert "<script>" not in banner_region
 
+    def test_error_banner_password_advice_only_for_bad_password_class(self, monkeypatch):
+        """litclock-dev#603 — the advice line branches on the failure class
+        carried by the WifiFailure error string."""
+        import wifi_provision
+
+        monkeypatch.setattr(
+            setup_server,
+            "WIFI_CONNECT_ERROR",
+            wifi_provision.WifiFailure("Incorrect WiFi password", wifi_provision.WIFI_FAIL_BAD_PASSWORD),
+        )
+        html = setup_server._build_setup_html()
+        assert "Double-check your <strong>WiFi password</strong>" in html
+
+    def test_error_banner_neutral_advice_for_timeout_class(self, monkeypatch):
+        """The bug litclock-dev#603 closes: 'the network didn't answer in
+        time' followed by 'double-check your WiFi password' is the page
+        arguing with itself."""
+        import wifi_provision
+
+        monkeypatch.setattr(
+            setup_server,
+            "WIFI_CONNECT_ERROR",
+            wifi_provision.WifiFailure(
+                "Couldn't reach 'Net' — the network didn't answer in time.",
+                wifi_provision.WIFI_FAIL_TIMEOUT,
+            ),
+        )
+        html = setup_server._build_setup_html()
+        assert "Double-check your" not in html
+        assert "Check the message above, then try again." in html
+        # The reconnection hint survives on every class — the hotspot DID
+        # restart out from under the phone regardless of why the join failed.
+        assert "rescan the QR code" in html
+
+    def test_error_banner_classless_string_gets_neutral_advice(self, monkeypatch):
+        """A plain-str error (legacy caller, unknown source) has no evidence
+        the password was the problem — neutral advice, per the same
+        no-evidence rule the e-ink variant uses."""
+        monkeypatch.setattr(setup_server, "WIFI_CONNECT_ERROR", "Setup error: something odd")
+        html = setup_server._build_setup_html()
+        assert "Double-check your" not in html
+        assert "Check the message above, then try again." in html
+
     def test_error_banner_with_literal_braces_in_error(self, monkeypatch):
         """Curly braces in error messages pass through verbatim — the
         banner is interpolated into an f-string template, not .format(),
@@ -1475,14 +1518,19 @@ class TestNoWiFiBranchSigterm:
         )
 
 
-class TestManualSsidEntry:
-    """litclock-dev#554: the hidden-SSID path through do_POST.
+class _ManualSsidHarness:
+    """Shared rig for the manual/hidden-SSID POST tests: fake
+    wifi_provision module, POST driver, thread drain. Deliberately holds no
+    tests — TestManualSsidEntry and TestManualSsidReviewHardening both
+    subclass THIS rather than each other, so neither re-runs the other's
+    cases under a second name for no coverage (litclock-dev#605 item 8 —
+    the same rule the entry class already applied to TestConnectAndTeardown,
+    then broke for its own subclass).
 
     Same fake-wifi_provision-in-sys.modules discipline as
     TestConnectAndTeardown — the background thread imports it at runtime, so
     the fake has to be installed before the POST and kept alive until the
-    thread drains. Not a subclass of it: pytest would re-run every inherited
-    test under this name for no coverage.
+    thread drains.
     """
 
     def _make_post_body(self, **overrides):
@@ -1519,10 +1567,21 @@ class TestManualSsidEntry:
         fake_wp.create_hotspot = lambda ssid=None, password=None: None
         return fake_wp
 
-    def _post(self, monkeypatch, tmp_env_file, connect_calls, scanned=None, **body):
+    def _post(
+        self,
+        monkeypatch,
+        tmp_env_file,
+        connect_calls,
+        scanned=None,
+        provisioning=True,
+        in_flight=False,
+        last_manual="",
+        connect_result=(True, None),
+        **body,
+    ):
         import sys
 
-        monkeypatch.setattr(setup_server, "PROVISIONING_MODE", True)
+        monkeypatch.setattr(setup_server, "PROVISIONING_MODE", provisioning)
         monkeypatch.setattr(setup_server, "ENV_FILE", tmp_env_file)
         monkeypatch.setattr(setup_server, "HOTSPOT_SSID", "LitClock-Setup")
         monkeypatch.setattr(setup_server, "_show_connecting_splash", lambda ssid: None)
@@ -1532,17 +1591,51 @@ class TestManualSsidEntry:
         # `hidden` is now decided against what the radio actually saw, so the
         # scan set is part of the fixture rather than incidental state.
         monkeypatch.setattr(setup_server, "_WIFI_SCAN_SSIDS", frozenset(scanned or ()))
-        monkeypatch.setattr(setup_server, "WIFI_LAST_MANUAL_SSID", "")
+        monkeypatch.setattr(setup_server, "WIFI_LAST_MANUAL_SSID", last_manual)
+        if in_flight:
+            # Simulate a live connect attempt: the CAS in do_POST must turn
+            # this request away before it stores or joins anything. No thread
+            # is spawned, so skip the wait below (IN_FLIGHT never clears).
+            monkeypatch.setattr(setup_server, "WIFI_CONNECT_IN_FLIGHT", True)
 
         sys.modules.pop("wifi_provision", None)
-        sys.modules["wifi_provision"] = self._fake_wp(connect_calls)
+        sys.modules["wifi_provision"] = self._fake_wp(connect_calls, result=connect_result)
         try:
             req = FakeRequest("POST", "/setup", self._make_post_body(**body))
             response = post_setup(make_handler(req))
-            self._wait_for_thread()
+            if not in_flight:
+                self._wait_for_thread()
             return response
         finally:
             sys.modules.pop("wifi_provision", None)
+
+
+class TestManualSsidEntry(_ManualSsidHarness):
+    """litclock-dev#554: the hidden-SSID path through do_POST."""
+
+    def test_failure_class_reaches_restore_hotspot_end_to_end(self, monkeypatch, tmp_env_file):
+        """litclock-dev#610 review: every other flow test fakes the connect
+        with a plain-string error, so the new contract at the important call
+        site — the thread assigning a WifiFailure to WIFI_CONNECT_ERROR and
+        extracting failure_class for _restore_hotspot — was pinned by
+        nothing. Drive the real object through the real thread."""
+        import wifi_provision
+
+        restore_calls = []
+        monkeypatch.setattr(
+            setup_server,
+            "_restore_hotspot",
+            lambda create_fn, failure_class=None: restore_calls.append(failure_class),
+        )
+        failure = wifi_provision.WifiFailure(
+            "Couldn't reach 'TestNetwork' — the network didn't answer in time.",
+            wifi_provision.WIFI_FAIL_TIMEOUT,
+        )
+        calls = []
+        self._post(monkeypatch, tmp_env_file, calls, connect_result=(False, failure))
+        assert calls, "connect must have been attempted"
+        assert restore_calls == ["timeout"]
+        assert setup_server.WIFI_CONNECT_ERROR is failure  # stored object, class intact
 
     def test_sentinel_plus_typed_name_joins_as_hidden(self, monkeypatch, tmp_env_file):
         """The sentinel is a form-transport artefact, never a network name.
@@ -1595,7 +1688,7 @@ class TestManualSsidEntry:
         assert calls == [("HomeWiFi", "secret123", False)]
 
     def test_sentinel_with_empty_field_is_rejected_with_a_specific_message(self, monkeypatch, tmp_env_file):
-        """"Please select a WiFi network" is wrong here — they did select
+        """ "Please select a WiFi network" is wrong here — they did select
         one. Tell them the thing they actually have to do."""
         calls = []
         response = self._post(
@@ -1667,12 +1760,12 @@ class TestManualSsidEntry:
         assert calls == [("N" * 32, "secret123", True)]
 
 
-class TestManualSsidReviewHardening(TestManualSsidEntry):
+class TestManualSsidReviewHardening(_ManualSsidHarness):
     """Second-round findings from the litclock-dev#580 review, on the POST path.
 
-    Subclasses TestManualSsidEntry only to reuse `_post` / `_fake_wp`; pytest
-    re-running the parent's cases here is accepted because these share the
-    same fixture surface and the parent class is small.
+    Subclasses the test-free harness for `_post` / `_fake_wp` — previously
+    this subclassed TestManualSsidEntry itself, re-running its nine
+    thread-spawning cases under a second name (litclock-dev#605 item 8).
     """
 
     def test_typed_name_the_radio_can_see_is_NOT_flagged_hidden(self, monkeypatch, tmp_env_file):
@@ -1823,3 +1916,85 @@ class TestManualSsidReviewHardening(TestManualSsidEntry):
         calls = []
         self._post(monkeypatch, tmp_env_file, calls, scanned={"homewifi"}, wifi_ssid="HomeWiFi")
         assert setup_server.WIFI_LAST_MANUAL_SSID == ""
+
+    @pytest.mark.parametrize(
+        "bad_value",
+        ["Evil\x00Net", "x" * 200, "LitClock-Setup", "litclock-setup"],
+        ids=["control-char", "over-long", "own-hotspot", "own-hotspot-casefold"],
+    )
+    def test_a_rejected_typed_name_is_never_stored(self, monkeypatch, tmp_env_file, bad_value):
+        """litclock-dev#605 item 10: the remembered name is a module global
+        echoed into every captive-portal client's render. A value the server
+        just REFUSED must not land there — that includes the own-hotspot
+        refusal (which sits BELOW the shape validations), so storage happens
+        only for a join actually launched. Each rejection class is its own
+        case so one regressing can't mask another."""
+        monkeypatch.setattr(setup_server, "WIFI_LAST_MANUAL_SSID", "")
+        calls = []
+        self._post(
+            monkeypatch,
+            tmp_env_file,
+            calls,
+            scanned=set(),
+            wifi_ssid=setup_server.MANUAL_SSID_VALUE,
+            **{setup_server.MANUAL_SSID_FIELD: bad_value},
+        )
+        assert setup_server.WIFI_LAST_MANUAL_SSID == ""
+        assert calls == []
+
+    def test_a_rejection_preserves_the_previously_stored_name(self, monkeypatch, tmp_env_file):
+        """Behavior change pinned deliberately: before litclock-dev#606 the
+        store ran ahead of the rejections, so an empty typed submit BLANKED a
+        previously remembered good name. Post-move the rejection returns
+        first and the prior value survives — the hidden-network user who
+        fat-fingers a resubmit keeps their echo."""
+        calls = []
+        self._post(
+            monkeypatch,
+            tmp_env_file,
+            calls,
+            scanned=set(),
+            last_manual="OldNet",
+            wifi_ssid=setup_server.MANUAL_SSID_VALUE,
+            **{setup_server.MANUAL_SSID_FIELD: ""},
+        )
+        assert setup_server.WIFI_LAST_MANUAL_SSID == "OldNet"
+        assert calls == []
+
+    def test_normal_mode_post_never_stores_a_typed_name(self, monkeypatch, tmp_env_file):
+        """The shape validations are all PROVISIONING_MODE-gated, so a
+        normal-mode POST reaches the old store site having passed ZERO
+        checks — unbounded bytes, control characters and all (adversarial
+        /review on litclock-dev#606). The store now lives inside the
+        provisioning-only connect branch, so normal mode cannot write the
+        global at all."""
+        calls = []
+        self._post(
+            monkeypatch,
+            tmp_env_file,
+            calls,
+            scanned=set(),
+            provisioning=False,
+            wifi_ssid=setup_server.MANUAL_SSID_VALUE,
+            **{setup_server.MANUAL_SSID_FIELD: "Evil\x00Net" + "x" * 100},
+        )
+        assert setup_server.WIFI_LAST_MANUAL_SSID == ""
+        assert calls == []
+
+    def test_a_post_that_loses_the_in_flight_race_does_not_store(self, monkeypatch, tmp_env_file):
+        """A POST that arrives while a connect attempt is live is turned away
+        by the CAS and never joins — its typed name must not become the
+        retry echo for an attempt it never made (Codex /review on
+        litclock-dev#606)."""
+        calls = []
+        self._post(
+            monkeypatch,
+            tmp_env_file,
+            calls,
+            scanned=set(),
+            in_flight=True,
+            wifi_ssid=setup_server.MANUAL_SSID_VALUE,
+            **{setup_server.MANUAL_SSID_FIELD: "RacingNet"},
+        )
+        assert setup_server.WIFI_LAST_MANUAL_SSID == ""
+        assert calls == []


### PR DESCRIPTION
File-level port of the wifi/provisioning seam of the litclock-dev #606-#631 train into the public repo. The companion PR ports the rest of the train; the two are file-disjoint and merge in either order.

## What ships (dev PRs folded here)

- **litclock-dev#630 + #616**: a reused profile's PSK survives a failed connect. #630 is the working form (the #616 snapshot listing is rejected by real nmcli, rc=2), and the PSK never transits nmcli argv (litclock-dev#599): connect uses `--ask` + stdin, restore uses `connection edit` with the secret fed on stdin. The version on public master today never fires.
- **litclock-dev#609**: snapshot-and-diff profile cleanup, so a failed provisioning attempt leaves no armed NM profile with a wrong PSK.
- **litclock-dev#610**: retry surfaces reflect the actual failure class (WifiFailure carries `failure_class`; e-ink retry variants; conditional banner advice).
- **litclock-dev#619**: the page-build scan path is serialized under `_SCAN_CACHE_LOCK`.
- **litclock-dev#625 + #629**: setup splash validates and clamps credentials (fixes the silent 10px font fallback); hotspot `--ssid`/`--password` validated where the AP is created; the `/etc/issue` box is sized at runtime and tested for alignment across the full admitted credential range.
- **litclock-dev#606**: wifi hygiene (redacted sentinel argv, post-validation SSID storage, honest litclock-update.timer comment).
- The litclock-dev#614 review-polish hunks that land in these files.

## Port method and verification

Per-file `public..dev` delta against a per-file merge base, never wholesale copies of diverged files (the repos diverge bidirectionally). Every ported file was verified equivalent to litclock-dev master after normalizing the `litclock-dev#NNN` ref requalification; an independent review pass additionally confirmed `wifi_provision.py` and `eink_display.py` are AST-identical to dev, and traced every PSK path (stdin only, argv redacted on both result shapes, no temp secret files exist).

Public-only content preserved and pinned by tests: the #529 Setup-Incomplete poweroff branch in `first-boot.sh` (dev's "Or SSH in" copy stays replaced by "Unplug, then plug back in") plus its `TestSetupIncompletePoweroff` class, alongside dev's new `TestIssueBoxAlignment`.

Gates on this branch's tree: ruff clean; pytest 3,098 passed (freetype-gated renderer tests executed locally in a freetype venv, zero relevant skips); the ported wifi suite also ran green from a clean archive export (370 passed).

One deliberate divergence from dev found in review and kept: a test fixture UUID token that carried a real-world SSID name was renamed to a neutral token.

## Fleet impact

None until a release is tagged: OTA is tag-gated, so merging to master exposes nobody. This train is the substance of the planned v0.224.0. Fresh-flash QA on the bench Pi matters more than usual for that release because the WiFi stack changed shape under litclock-dev#630, and fresh-flash is exactly what exercises it.
