### PR TITLE
fix: dead-updater detection, slug allowlist, SSH-off gate on factory-reset poweroff

### DIFF
--- a/scripts/download_images.sh
+++ b/scripts/download_images.sh
@@ -384,10 +384,15 @@ derive_repo_slug() {
     esac
     # Keep the LAST two path segments so nested paths still resolve.
     slug=$(printf '%s\n' "$path" | awk -F/ 'NF>=2 {printf "%s/%s", $(NF-1), $NF}')
-    case "$slug" in
-        */*) printf '%s\n' "$slug" ;;
-        *) return 1 ;;
-    esac
+    # Anchored allowlist (litclock-dev#636, mirrors build-image.yml's ref_ok): the slug is
+    # spliced into api.github.com URLs, so a crafted origin URL carrying '?',
+    # '#', '&', '%', or whitespace could reshape the request path/query.
+    # GitHub owner/repo names never need characters outside this set.
+    [[ "$slug" =~ ^[A-Za-z0-9][A-Za-z0-9._-]*/[A-Za-z0-9._-]+$ ]] || return 1
+    # Pure-dot repo segments pass the allowlist but curl squashes dot
+    # segments, remapping the API path ('owner/..' resolves outside /repos).
+    case "${slug##*/}" in .|..) return 1 ;; esac
+    printf '%s\n' "$slug"
 }
 
 

--- a/scripts/first-boot.sh
+++ b/scripts/first-boot.sh
@@ -85,7 +85,7 @@ display_message() {
     local submessage="$3"
 
     if [[ -f "$INSTALL_DIR/src/eink_display.py" ]]; then
-        cd "$INSTALL_DIR" || return || return
+        cd "$INSTALL_DIR" || return
         timeout 20 "$PYTHON" src/eink_display.py status "$title" ${message:+--message "$message"} ${submessage:+--submessage "$submessage"} || true
     fi
 }
@@ -177,7 +177,7 @@ display_hotspot() {
     local ip="$3"
 
     if [[ -f "$INSTALL_DIR/src/eink_display.py" ]]; then
-        cd "$INSTALL_DIR" || return || return
+        cd "$INSTALL_DIR" || return
         timeout 20 "$PYTHON" src/eink_display.py hotspot "$ssid" "$password" "$ip" || true
     fi
 }
@@ -189,7 +189,7 @@ display_qr() {
     local caption="$3"
 
     if [[ -f "$INSTALL_DIR/src/eink_display.py" ]]; then
-        cd "$INSTALL_DIR" || return || return
+        cd "$INSTALL_DIR" || return
         timeout 20 "$PYTHON" src/eink_display.py qr "$url" ${title:+--title "$title"} ${caption:+--caption "$caption"} || true
     fi
 }
@@ -333,7 +333,7 @@ wait_for_setup() {
             # Server died unexpectedly — restart it
             log "Setup server exited unexpectedly, restarting..."
             display_message "Setup Server" "Restarting setup page..." ""
-            cd "$INSTALL_DIR" || return || return
+            cd "$INSTALL_DIR" || return
             if [[ "${PROVISIONING:-}" == "true" ]]; then
                 "$PYTHON" src/setup_server.py "$ENV_FILE" "$SIGNAL_FILE" --provisioning \
                     --hotspot-ssid "${HOTSPOT_SSID:-}" --hotspot-password "${HOTSPOT_PASSWORD:-}" &
@@ -376,7 +376,7 @@ start_clock_service() {
     else
         # Run the clock directly
         log "Running clock directly..."
-        cd "$INSTALL_DIR" || return || return
+        cd "$INSTALL_DIR" || return
         ./scripts/runtheclock.sh &
     fi
 

--- a/scripts/reset-setup.sh
+++ b/scripts/reset-setup.sh
@@ -417,6 +417,67 @@ EOF
     fi
 fi
 
+# #528 + litclock-dev#636: force SSH off before the device leaves the owner's
+# hands, shared by BOTH handoff paths — gift mode (ships to a recipient) and
+# the non-gift factory-reset poweroff (the PWA copy invites "move or pass the
+# clock on"). The image ships SSH off, but an owner who enabled it (QA,
+# recovery, tinkering) would otherwise hand over a device with SSH listening +
+# the well-known default creds the moment it joins the next network.
+# Idempotent belt-and-suspenders across every way SSH can be on:
+#   - ssh.socket — Raspberry Pi OS Bookworm SOCKET-ACTIVATES sshd: pid 1
+#     holds port 22 via ssh.socket and spawns sshd per-connection.
+#     Disabling ssh.service alone leaves the socket listening, so the
+#     socket MUST be disabled — this is the load-bearing unit on
+#     current images (hardware QA 2026-07-16 caught a service-only
+#     disable leaving port 22 open after reprovision). Disabled in a
+#     SEPARATE call from ssh.service so a missing unit on an older
+#     service-only image can't abort the other disable (/review).
+#   - ssh.service — the classic always-on unit (older images).
+#   - raspi-config do_ssh 1 — the canonical toggle; covers whatever the
+#     image's native mechanism is.
+#   - boot-partition flags — sshswitch.service turns SSH back on at boot
+#     if a bare `ssh` file exists on /boot or /boot/firmware.
+# Callers place this AFTER their fatal env-wipe gates: on a failed prep the
+# device stays on and the owner may still need SSH to fix it (--poweroff
+# implies --strict-env-wipe, so its wipe failure aborted long before here).
+# Runs fine over an SSH session — pam_systemd puts interactive sessions in
+# their own scope, so stopping the unit doesn't kill the invoking shell
+# (and the caller's poweroff ends it anyway). Re-enable via console per
+# docs/recovery.md, same as a fresh flash.
+disable_ssh_for_handoff() {
+    echo -n "Disabling SSH before handoff... "
+    systemctl disable --now ssh.socket 2>/dev/null || true
+    systemctl disable --now ssh.service 2>/dev/null || true
+    raspi-config nonint do_ssh 1 2>/dev/null || true
+    rm -f /boot/ssh /boot/ssh.txt /boot/firmware/ssh /boot/firmware/ssh.txt 2>/dev/null || true
+    echo -e "${GREEN}done${NC}"
+
+    # #528 /review: SSH-off is a security GATE, so verify port 22 is
+    # actually closed rather than trusting the best-effort disables above
+    # (each is `|| true`, and socket-activation means the service state
+    # alone doesn't prove the port is shut). If sshd still listens, refuse
+    # to power off: handing over a device with SSH + default creds
+    # reachable on someone else's network is exactly what this step exists
+    # to prevent. `ss` ships in iproute2 (always present on Pi OS); if it
+    # can't run we can't verify, so warn and proceed rather than
+    # hard-block a handoff on missing tooling.
+    if command -v ss >/dev/null 2>&1; then
+        # Extract the local port (last colon-field of the Local Address
+        # column) and match EXACTLY 22 — avoids false hits on :2222, :220…
+        if ss -H -ltn 2>/dev/null | awk '{n=split($4,a,":"); print a[n]}' | grep -qx 22; then
+            echo -e "${RED}========================================${NC}"
+            echo -e "${RED}  SSH still listening — do NOT hand this device over${NC}"
+            echo -e "${RED}========================================${NC}"
+            echo -e "${RED}Port 22 is still open after disabling SSH. NOT powering off${NC}"
+            echo -e "${RED}so a device with SSH + default creds isn't passed on. Check:${NC}"
+            echo -e "${YELLOW}  systemctl status ssh.socket ssh.service${NC}"
+            exit 1
+        fi
+    else
+        echo -e "${YELLOW}Note: 'ss' unavailable — could not verify port 22 is closed.${NC}"
+    fi
+}
+
 echo ""
 echo "========================================"
 echo -e "${GREEN}  Reset Complete!${NC}"
@@ -446,61 +507,10 @@ if [[ "$GIFT_MODE" == "true" ]]; then
         echo -e "${YELLOW}  sudo $0 --gift-mode${NC}"
         exit 1
     fi
-    # #528: force SSH off before shipping. The image ships SSH off, but an
-    # owner who enabled it (QA, recovery, tinkering) would otherwise hand
-    # the recipient a device with SSH listening + the well-known default
-    # creds the moment it joins THEIR network. Idempotent belt-and-
-    # suspenders across every way SSH can be on:
-    #   - ssh.socket — Raspberry Pi OS Bookworm SOCKET-ACTIVATES sshd: pid 1
-    #     holds port 22 via ssh.socket and spawns sshd per-connection.
-    #     Disabling ssh.service alone leaves the socket listening, so the
-    #     socket MUST be disabled — this is the load-bearing unit on
-    #     current images (hardware QA 2026-07-16 caught a service-only
-    #     disable leaving port 22 open after reprovision). Disabled in a
-    #     SEPARATE call from ssh.service so a missing unit on an older
-    #     service-only image can't abort the other disable (/review).
-    #   - ssh.service — the classic always-on unit (older images).
-    #   - raspi-config do_ssh 1 — the canonical toggle; covers whatever the
-    #     image's native mechanism is.
-    #   - boot-partition flags — sshswitch.service turns SSH back on at boot
-    #     if a bare `ssh` file exists on /boot or /boot/firmware.
-    # Deliberately AFTER the env-wipe-failed gate above: on a failed prep
-    # the device stays on and the owner may still need SSH to fix it. Runs
-    # even over an SSH session — pam_systemd puts interactive sessions in
-    # their own scope, so stopping the unit doesn't kill the invoking shell
-    # (and the poweroff below ends it anyway). Recipient re-enables via
-    # console per docs/recovery.md, same as a fresh flash.
-    echo -n "Disabling SSH for shipping... "
-    systemctl disable --now ssh.socket 2>/dev/null || true
-    systemctl disable --now ssh.service 2>/dev/null || true
-    raspi-config nonint do_ssh 1 2>/dev/null || true
-    rm -f /boot/ssh /boot/ssh.txt /boot/firmware/ssh /boot/firmware/ssh.txt 2>/dev/null || true
-    echo -e "${GREEN}done${NC}"
-
-    # #528 /review: SSH-off is a security GATE, so verify port 22 is
-    # actually closed rather than trusting the best-effort disables above
-    # (each is `|| true`, and socket-activation means the service state
-    # alone doesn't prove the port is shut). If sshd still listens, refuse
-    # to power off — same posture as the env-wipe failure below: shipping a
-    # device with SSH + default creds reachable on the recipient's network
-    # is exactly what this step exists to prevent. `ss` ships in iproute2
-    # (always present on Pi OS); if it can't run we can't verify, so warn
-    # and proceed rather than hard-block a gift on missing tooling.
-    if command -v ss >/dev/null 2>&1; then
-        # Extract the local port (last colon-field of the Local Address
-        # column) and match EXACTLY 22 — avoids false hits on :2222, :220…
-        if ss -H -ltn 2>/dev/null | awk '{n=split($4,a,":"); print a[n]}' | grep -qx 22; then
-            echo -e "${RED}========================================${NC}"
-            echo -e "${RED}  SSH still listening — do NOT ship this device${NC}"
-            echo -e "${RED}========================================${NC}"
-            echo -e "${RED}Port 22 is still open after disabling SSH. NOT powering off${NC}"
-            echo -e "${RED}so a device with SSH + default creds isn't shipped. Check:${NC}"
-            echo -e "${YELLOW}  systemctl status ssh.socket ssh.service${NC}"
-            exit 1
-        fi
-    else
-        echo -e "${YELLOW}Note: 'ss' unavailable — could not verify port 22 is closed.${NC}"
-    fi
+    # #528 — shared handoff gate; see disable_ssh_for_handoff above.
+    # Deliberately AFTER the env-wipe-failed gate: on a failed prep the
+    # device stays on and the owner may still need SSH to fix it.
+    disable_ssh_for_handoff
 
     # Marker was written earlier (pre-stop) so shutdown-splash has already
     # painted the welcome screen by now. Just power off.
@@ -515,6 +525,11 @@ elif [[ "$DO_POWEROFF" == "true" ]]; then
     # aborted before here if the config wipe failed, so a clean slate is
     # guaranteed by the time we power off. On next power-on the wiped config
     # makes first-boot run into the setup hotspot.
+    #
+    # litclock-dev#636 — the copy above this flow invites "move or pass the
+    # clock on", so this path must leave the device in the same SSH posture
+    # a recipient would get from a gift or a fresh flash: off.
+    disable_ssh_for_handoff
     echo "Powering off. Power the clock on again to set it up fresh."
     poweroff
 elif [[ "$DO_REBOOT" == "true" ]]; then

--- a/src/control_server/routes/updates.py
+++ b/src/control_server/routes/updates.py
@@ -430,8 +430,18 @@ def status() -> tuple[object, int]:
         # `stale` is deliberately NOT inferred (review): a torn read
         # self-corrects within one atomic-write tick, and inventing phase 1
         # for it would visually regress a mid-run reading list. A `running`
-        # file also passes through un-checked here — the dead-updater
-        # cross-check lives on the page render only, where a wrong answer
-        # costs a reload instead of a terminal verdict mid-poll-loop.
+        # file also passes through with its state intact — but see below.
         payload = {"state": "running", "phase_index": 1, "inferred": "unit-busy"}
+    if payload.get("state") == "running":
+        # litclock-dev#636 — a `running` file with an idle unit is a dead updater
+        # (SIGKILL/OOM skips the EXIT trap and the file lies until reboot
+        # clears tmpfs). The route still never issues that verdict itself:
+        # one sample can be the 2s memo lagging the dispatch window, and a
+        # false "dead" mid-run would resurrect the litclock-dev#607 stale-card bug. It
+        # exposes the evidence instead — updates.js requires several
+        # consecutive idle-unit readings before it stops treating the run
+        # as live, and the server-rendered page keeps the authoritative
+        # cross-check via _live_run(). The inferred-busy payload above is
+        # unit-busy by construction, so unit_busy=True there is exact.
+        payload = {**payload, "unit_busy": _unit_busy_memoized()}
     return jsonify({"ok": True, **payload}), 200

--- a/src/control_server/static/js/updates.js
+++ b/src/control_server/static/js/updates.js
@@ -188,6 +188,16 @@
       return;
     }
     if (payload.state === 'running') {
+      if (payload.unit_busy === false) {
+        // litclock-dev#636 — cold load onto a dead-updater candidate: the server-rendered
+        // card is the truthful surface, so don't swap in a reading list on
+        // the file's word alone. Poll instead — if the idle reading was the
+        // unit memo lagging a real run, the next poll flips unit_busy true
+        // and the poll loop promotes the page into the reading list; if it
+        // was a real corpse, the loop confirms and stops quietly.
+        schedulePoll();
+        return;
+      }
       seenRunning = true;                              // litclock-dev#342 I10 — arm phantom-tick + reconnect-mode
       enterReadingList(payload);
       schedulePoll();                                  // litclock-dev#342 I10 — keep advancing
@@ -234,6 +244,7 @@
           // optimistic-tick branch fires even if the very first scheduled
           // poll times out (e.g. Phase 7 restart racing the 2s interval).
           seenRunning = true;
+          deadUpdaterPolls = 0;  // litclock-dev#636 — a fresh Apply is a fresh corpse-evidence window
           // litclock-dev#354 codex P2 follow-up — fireApply owns the new running
           // state on success; the deferred probe (if any) is now stale.
           deferredProbePayload = null;
@@ -287,6 +298,7 @@
         // Apply, so we're in a "running" intent for the duration regardless
         // of whether the POST round-tripped cleanly.
         seenRunning = true;
+        deadUpdaterPolls = 0;  // litclock-dev#636 — same: new run, stale corpse count must not carry
         // litclock-dev#354 codex P2 follow-up — optimistic enterReadingList here
         // claims the running state; drop any deferred probe so it can't
         // overwrite the optimistic phase_index when the close listener
@@ -378,6 +390,16 @@
   // restart window and far beyond any single-poll hiccup.
   var POLL_FAILURE_THRESHOLD = 3;
   var consecutivePollFailures = 0;
+  // litclock-dev#636 — dead-updater detection. A `running` status file with an idle
+  // unit means the updater died without its EXIT trap (SIGKILL/OOM) and the
+  // file lies until reboot clears tmpfs; without this, an already-open page
+  // polls a corpse forever. One idle reading proves nothing (the server's
+  // 2s unit memo can lag the dispatch window), so require several
+  // consecutive ones — at the 2s poll interval the threshold spans ~10s,
+  // comfortably past any memo/activation gap. The verdict is deliberately
+  // NOT a reload: the dead file persists, so a reload would loop.
+  var DEAD_UPDATER_POLL_THRESHOLD = 5;
+  var deadUpdaterPolls = 0;
 
   function cancelPolling() {
     // Bump the generation so any captured-by-closure callback (pending
@@ -474,7 +496,44 @@
       return;
     }
     if (payload.state === 'running') {
+      if (payload.unit_busy === false) {
+        // litclock-dev#636 — dead-updater candidate. Keep polling (and keep the list
+        // as-is) until the evidence is sustained, then stop with honest
+        // terminal copy instead of spinning forever. seenRunning stays
+        // untouched here: arming phantom-tick off a corpse file would
+        // paint 7 green phases for an update that never finished.
+        deadUpdaterPolls++;
+        if (deadUpdaterPolls >= DEAD_UPDATER_POLL_THRESHOLD) {
+          cancelPolling();
+          if (readingList && !readingList.hidden) {
+            // Freeze the reading list honestly: mark the in-flight phase
+            // failed so a spinner doesn't keep animating above copy that
+            // says the updater is gone (review).
+            updateRowStates(payload.phase_index || 0, true);
+            showTerminal(
+              'The update stopped before finishing (the updater is no longer running). ' +
+              'Your clock may still be on its previous version. Reload this page and try Apply again.',
+              'error'
+            );
+          }
+          return;
+        }
+        updateRowStates(payload.phase_index || 0, false);
+        schedulePoll();
+        return;
+      }
+      deadUpdaterPolls = 0;
       seenRunning = true;
+      if (readingList && readingList.hidden && !(dialog && dialog.open)) {
+        // litclock-dev#636 — the cold-load probe deferred entry on a dead-updater
+        // candidate; the unit is confirmed busy now, so promote the page
+        // into the in-progress view it would normally have entered. The
+        // dialog guard mirrors the litclock-dev#354 probe deferral: yanking the
+        // card into the reading list under an open confirm sheet is the
+        // exact race that guard exists for — skip this tick and let the
+        // next poll promote after the sheet closes.
+        enterReadingList(payload);
+      }
       updateRowStates(payload.phase_index || 0, false);
       schedulePoll();
       return;
@@ -643,6 +702,7 @@
             // may never come.
             reconnectArmed = false;
             consecutivePollFailures = 0;
+            deadUpdaterPolls = 0;  // litclock-dev#636 — resuming a live run is fresh evidence
             enterReadingList(statusBody);
             schedulePoll();
             return;

--- a/src/setup_server.py
+++ b/src/setup_server.py
@@ -103,7 +103,15 @@ SSID_MAX_BYTES = 32
 # Storage=persistent on the flashed image, and the support bundle collects
 # it) and reaches the e-ink connecting splash. Same class as the env.sh
 # splitlines round-trip: reject at the entry point, do not sanitise downstream.
-SSID_FORBIDDEN = frozenset(chr(c) for c in range(0x20)) | {chr(0x7F)} | frozenset(chr(c) for c in range(0x80, 0xA0))
+# U+2028/U+2029 ride along with the C0/C1 controls: Python's isprintable()
+# treats them as unprintable (the renderer already strips them) but they are
+# not in the C1 range, so without this the reject-before-journal comment
+# below would overclaim (litclock-dev#636).
+SSID_FORBIDDEN = (
+    frozenset(chr(c) for c in range(0x20))
+    | {chr(0x7F), "\u2028", "\u2029"}
+    | frozenset(chr(c) for c in range(0x80, 0xA0))
+)
 
 # Thread safety: the server runs in threaded mode so a stuck handler can't
 # block new connections. These locks guard state mutated from both request

--- a/sudoers/020_litclock-control
+++ b/sudoers/020_litclock-control
@@ -46,8 +46,9 @@
 # Issue litclock-dev#510 entry:
 #   * `systemctl start --no-block litclock-reset.service` — /api/system/reset
 #     (Factory reset). The unit's ExecStart is reset-setup.sh --wipe-wifi
-#     --reboot --yes (full wipe + reboot into setup). Fixed argv, no user
-#     input crosses the sudo boundary. Sibling of the wifi-reset/gift grants.
+#     --strict-env-wipe --poweroff --yes (full wipe + power off for pack-up,
+#     litclock-dev#627). Fixed argv, no user input crosses the sudo boundary. Sibling of
+#     the wifi-reset/gift grants.
 #
 # EPIC litclock-dev#383 PR2 (litclock-dev#388) entry:
 #   * `touch /etc/litclock/.handoff-complete` — control_server's handoff

--- a/tests/js/updates.dead-updater.test.js
+++ b/tests/js/updates.dead-updater.test.js
@@ -1,0 +1,284 @@
+// Behavior coverage for the litclock-dev#636 dead-updater rules in updates.js.
+//
+// The bug (Codex, litclock-dev#634 port review): /api/update/status passes a `running`
+// status file through even when the unit is idle — the dead-updater state
+// (`running` file + idle unit; SIGKILL/OOM skipped update.sh's EXIT trap,
+// and the file lies until reboot clears tmpfs). The JS poll loop treated
+// every `running` as live and rescheduled forever, so an already-open
+// Updates page spun on a corpse until a manual reload.
+//
+// The fix keeps the route's verdict-free posture (litclock-dev#607 review: a false
+// "dead" mid-run would resurrect the stale-card bug) and splits the work:
+// the route reports the evidence (`unit_busy` on running payloads), and the
+// poll loop acts only on SUSTAINED evidence:
+//
+// 1. LIVE RUNS UNAFFECTED — unit_busy:true keeps the counter at zero; a
+//    payload with NO unit_busy field (pre-#636 server) is treated as live
+//    forever, never counted toward a dead verdict.
+// 2. SUSTAINED DEAD → TERMINAL, NOT RELOAD — DEAD_UPDATER_POLL_THRESHOLD
+//    consecutive unit_busy:false readings stop polling and (if the reading
+//    list is showing) render honest terminal copy. A reload is forbidden:
+//    the dead file persists, so reloading would loop.
+// 3. A SINGLE IDLE READING PROVES NOTHING — the server's 2s unit memo can
+//    lag the dispatch window; any unit_busy:true resets the counter.
+// 4. COLD LOAD ONTO A CORPSE — the probe must NOT swap the truthful
+//    server-rendered card for a reading list on the file's word alone; it
+//    polls, and promotes into the reading list only once the unit is
+//    confirmed busy.
+//
+// Pattern notes: state-flag mocks per tests/js house rules (the IIFE
+// re-runs on every loadScript — see helpers/loadScript.js docstring).
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { loadScript, installFetchMock, stubDialog } from "./helpers/loadScript.js";
+
+function buildDom({ inProgress = false, phase = 3 } = {}) {
+  const rowState = (idx) =>
+    !inProgress ? "upcoming" : idx < phase ? "completed" : idx === phase ? "active" : "upcoming";
+  document.body.innerHTML = `
+    <section id="updates-card" data-state="available" data-current-version="0.223.0"
+             ${inProgress ? "hidden" : ""}>
+      <form action="/api/update/apply" data-confirm-action="update_apply">
+        <input type="hidden" name="token" value="test-token-abcd" />
+        <button type="submit">Apply</button>
+      </form>
+    </section>
+
+    <dialog class="confirm-sheet" data-action="update_apply">
+      <button type="button" data-modal-cancel>Cancel</button>
+      <button type="button" data-modal-confirm>Confirm</button>
+    </dialog>
+
+    <ol id="phase-reading-list" ${inProgress ? "" : "hidden"}>
+      ${[1, 2, 3, 4, 5, 6, 7]
+        .map(
+          (i) =>
+            `<li class="phase-row" data-phase-index="${i}" data-state="${rowState(i)}"></li>`
+        )
+        .join("\n")}
+    </ol>
+    <p id="phase-terminal-message" hidden></p>
+  `;
+}
+
+async function flushMicrotasks() {
+  for (let i = 0; i < 5; i++) {
+    await Promise.resolve();
+  }
+}
+
+function statusCalls(mock) {
+  return mock.calls.filter((c) => c.path === "/api/update/status").length;
+}
+
+function terminalEl() {
+  return document.getElementById("phase-terminal-message");
+}
+
+function readingListEl() {
+  return document.getElementById("phase-reading-list");
+}
+
+// Per-call sequencer: yields each body in order, then repeats the last one.
+function sequencedStatus(bodies) {
+  const queue = bodies.slice();
+  return () => {
+    const body = queue.length > 1 ? queue.shift() : queue[0];
+    return { ok: true, status: 200, json: async () => body, text: async () => JSON.stringify(body) };
+  };
+}
+
+const running = (phase, unitBusy) => {
+  const body = { ok: true, state: "running", phase_index: phase };
+  if (unitBusy !== undefined) body.unit_busy = unitBusy;
+  return body;
+};
+
+describe("updates.js litclock-dev#636 dead-updater detection", () => {
+  let mock;
+  let restoreDialog = () => {};
+
+  beforeEach(() => {
+    restoreDialog = stubDialog();
+    vi.useFakeTimers();
+    mock = installFetchMock();
+  });
+
+  afterEach(() => {
+    mock.restore();
+    restoreDialog();
+    restoreDialog = () => {};
+    vi.useRealTimers();
+  });
+
+  it("rule 1: unit_busy:true and field-absent payloads never accumulate a dead verdict", async () => {
+    buildDom({ inProgress: true, phase: 3 });
+    // Alternate true/absent — neither may count toward the threshold.
+    mock.register(
+      /\/api\/update\/status$/,
+      sequencedStatus([running(3, true), running(3), running(4, true), running(4), running(4, true), running(4)])
+    );
+
+    loadScript("updates.js");
+    await flushMicrotasks();
+    for (let i = 0; i < 8; i++) {
+      await vi.advanceTimersByTimeAsync(2000);
+      await flushMicrotasks();
+    }
+
+    expect(terminalEl().hidden, "no terminal copy on a live run").toBe(true);
+    // Polling is still alive well past the threshold span.
+    const before = statusCalls(mock);
+    await vi.advanceTimersByTimeAsync(2000);
+    await flushMicrotasks();
+    expect(statusCalls(mock)).toBeGreaterThan(before);
+  });
+
+  it("rule 2: five consecutive unit_busy:false polls stop polling and show honest terminal copy", async () => {
+    buildDom({ inProgress: true, phase: 4 });
+    mock.register(/\/api\/update\/status$/, sequencedStatus([running(4, false)]));
+
+    loadScript("updates.js");
+    await flushMicrotasks();
+    for (let i = 0; i < 7; i++) {
+      await vi.advanceTimersByTimeAsync(2000);
+      await flushMicrotasks();
+    }
+
+    expect(terminalEl().hidden, "terminal copy must render once the corpse is confirmed").toBe(false);
+    expect(terminalEl().textContent).toMatch(/stopped before finishing/i);
+    expect(terminalEl().textContent).toMatch(/previous version/i);
+
+    // Polling stopped — and no reload was issued (the dead file persists;
+    // a reload would loop). jsdom throws on navigation, so reaching this
+    // point without an error is itself the no-reload proof; pin the
+    // poll-stop explicitly:
+    const settled = statusCalls(mock);
+    await vi.advanceTimersByTimeAsync(10000);
+    await flushMicrotasks();
+    expect(statusCalls(mock), "polling must stop at the dead verdict").toBe(settled);
+  });
+
+  it("rule 3: a unit_busy:true reading resets the counter — 4 dead + live + 4 dead stays live", async () => {
+    buildDom({ inProgress: true, phase: 2 });
+    const seq = [
+      running(2, false), running(2, false), running(2, false), running(2, false),
+      running(3, true),
+      running(3, false), running(3, false), running(3, false), running(3, false),
+      running(3, true),
+    ];
+    mock.register(/\/api\/update\/status$/, sequencedStatus(seq));
+
+    loadScript("updates.js");
+    await flushMicrotasks();
+    // Probe consumes seq[0]; 9 more polls consume the rest.
+    for (let i = 0; i < 9; i++) {
+      await vi.advanceTimersByTimeAsync(2000);
+      await flushMicrotasks();
+    }
+
+    expect(terminalEl().hidden, "4+4 non-consecutive dead readings must not verdict").toBe(true);
+    const before = statusCalls(mock);
+    await vi.advanceTimersByTimeAsync(2000);
+    await flushMicrotasks();
+    expect(statusCalls(mock)).toBeGreaterThan(before);
+  });
+
+  it("rule 4: cold load onto a corpse keeps the card; a confirmed-busy poll promotes into the reading list", async () => {
+    buildDom(); // card view — server render already applied the authoritative check
+    mock.register(/\/api\/update\/check$/, { status: 200, body: { ok: true, available: true } });
+    mock.register(
+      /\/api\/update\/status$/,
+      sequencedStatus([running(1, false), running(2, true)])
+    );
+
+    loadScript("updates.js");
+    await flushMicrotasks();
+
+    // Probe saw running+unit_busy:false — the reading list must NOT appear.
+    expect(readingListEl().hidden, "probe must not trust a corpse file on cold load").toBe(true);
+
+    // Next poll confirms the unit busy (memo lag case) — promote.
+    await vi.advanceTimersByTimeAsync(2000);
+    await flushMicrotasks();
+    expect(readingListEl().hidden, "confirmed-busy poll promotes into the in-progress view").toBe(false);
+  });
+
+  it("rule 5: a fresh Apply resets the corpse counter — one stale idle sample cannot kill the new run", async () => {
+    // Codex P1 on the litclock-dev#636 review: after a corpse verdict the
+    // counter sat at threshold; without the fireApply reset, the FIRST
+    // running+unit_busy:false sample of the next run (entirely possible —
+    // the route's 2s unit memo can still hold the corpse-era False right
+    // after dispatch) instantly re-tripped the threshold and rendered a
+    // false dead-updater terminal over a healthy fresh run.
+    buildDom();
+    mock.register(/\/api\/update\/check$/, { status: 200, body: { ok: true, available: true } });
+    mock.register(/\/api\/update\/apply$/, { status: 202, body: { ok: true } });
+    const seq = [
+      // cold-load probe + 5 polls confirm the corpse (counter hits threshold)
+      running(1, false),
+      // post-Apply: one stale-memo idle sample, then the run is visibly live
+      running(1, false), running(2, true), running(3, true),
+    ];
+    // First entry repeats for the corpse phase; switch the sequencer after.
+    let phase2 = false;
+    let i = 0;
+    mock.register(/\/api\/update\/status$/, () => {
+      const body = phase2 ? seq[Math.min(1 + i++, seq.length - 1)] : seq[0];
+      return { ok: true, status: 200, json: async () => body, text: async () => JSON.stringify(body) };
+    });
+
+    loadScript("updates.js");
+    await flushMicrotasks();
+    for (let k = 0; k < 7; k++) {
+      await vi.advanceTimersByTimeAsync(2000);
+      await flushMicrotasks();
+    }
+    // Corpse confirmed quietly (card view), polling stopped.
+    const settled = statusCalls(mock);
+    await vi.advanceTimersByTimeAsync(4000);
+    await flushMicrotasks();
+    expect(statusCalls(mock)).toBe(settled);
+
+    // User taps Apply for a fresh run.
+    phase2 = true;
+    const form = document.querySelector("form[data-confirm-action='update_apply']");
+    form.dispatchEvent(new Event("submit", { cancelable: true }));
+    document.querySelector("[data-modal-confirm]").click();
+    await flushMicrotasks();
+    expect(readingListEl().hidden, "fresh Apply enters the reading list").toBe(false);
+
+    // One stale idle sample must NOT terminal the fresh run…
+    await vi.advanceTimersByTimeAsync(2000);
+    await flushMicrotasks();
+    expect(terminalEl().hidden, "single stale sample after Apply must not verdict").toBe(true);
+    // …and the run keeps advancing normally once the memo catches up.
+    await vi.advanceTimersByTimeAsync(4000);
+    await flushMicrotasks();
+    expect(terminalEl().hidden).toBe(true);
+    const before = statusCalls(mock);
+    await vi.advanceTimersByTimeAsync(2000);
+    await flushMicrotasks();
+    expect(statusCalls(mock), "polling continues on the live run").toBeGreaterThan(before);
+  });
+
+  it("rule 4b: cold load onto a confirmed corpse stops quietly — card stays, no terminal copy", async () => {
+    buildDom();
+    mock.register(/\/api\/update\/check$/, { status: 200, body: { ok: true, available: true } });
+    mock.register(/\/api\/update\/status$/, sequencedStatus([running(1, false)]));
+
+    loadScript("updates.js");
+    await flushMicrotasks();
+    for (let i = 0; i < 7; i++) {
+      await vi.advanceTimersByTimeAsync(2000);
+      await flushMicrotasks();
+    }
+
+    expect(readingListEl().hidden, "card remains the surface").toBe(true);
+    expect(terminalEl().hidden, "no terminal copy outside the reading list").toBe(true);
+    const settled = statusCalls(mock);
+    await vi.advanceTimersByTimeAsync(10000);
+    await flushMicrotasks();
+    expect(statusCalls(mock), "polling stops on the confirmed corpse").toBe(settled);
+  });
+});

--- a/tests/test_control_server_updates_routes.py
+++ b/tests/test_control_server_updates_routes.py
@@ -638,6 +638,58 @@ class TestApiUpdateStatus:
         body = client.get("/api/update/status").json
         assert body["state"] == "idle"
 
+    def _write_running_file(self):
+        status_file = Path(os.environ.get("LITCLOCK_UPDATE_STATUS_FILE"))
+        status_file.parent.mkdir(parents=True, exist_ok=True)
+        status_file.write_text(json.dumps({"state": "running", "phase_index": 3}))
+
+    def test_running_with_busy_unit_reports_unit_busy_true(self, client):
+        """litclock-dev#636 — a live run carries unit_busy=True so the poll loop's
+        dead-updater counter stays at zero for the whole run."""
+        self._write_running_file()
+        with patch("control_server.routes.updates.update_state.update_is_busy", return_value=True):
+            body = client.get("/api/update/status").json
+        assert body["state"] == "running"
+        assert body["unit_busy"] is True
+
+    def test_running_with_idle_unit_keeps_state_but_reports_unit_busy_false(self, client):
+        """litclock-dev#636 — the dead-updater case (SIGKILL/OOM skipped the EXIT trap;
+        the file lies until reboot clears tmpfs). The route must NOT flip
+        the state itself — one sample can be the 2s memo lagging the
+        dispatch window, and a false 'dead' mid-run would resurrect the
+        litclock-dev#607 stale-card bug. It reports the evidence and the JS requires
+        several consecutive idle readings before acting."""
+        self._write_running_file()
+        body = client.get("/api/update/status").json
+        assert body["state"] == "running"
+        assert body["phase_index"] == 3
+        assert body["unit_busy"] is False
+
+    def test_inferred_running_reports_unit_busy_true(self, client):
+        """litclock-dev#636 — the litclock-dev#607 inferred-busy payload exists only because the
+        unit IS busy, so its unit_busy must be exactly True (a False here
+        would mean the inference and the evidence contradict each other)."""
+        with patch("control_server.routes.updates.update_state.update_is_busy", return_value=True):
+            body = client.get("/api/update/status").json
+        assert body["state"] == "running"
+        assert body["inferred"] == "unit-busy"
+        assert body["unit_busy"] is True
+
+    def test_non_running_states_carry_no_unit_busy_key(self, client):
+        """litclock-dev#636 — the evidence field is scoped to the one state whose
+        truthfulness it qualifies; terminal and idle payloads stay
+        byte-compatible with pre-#636 clients."""
+        status_file = Path(os.environ.get("LITCLOCK_UPDATE_STATUS_FILE"))
+        status_file.parent.mkdir(parents=True, exist_ok=True)
+        for state in ("complete", "failed_reverted", "failed_unrecovered"):
+            status_file.write_text(json.dumps({"state": state, "phase_index": 7}))
+            body = client.get("/api/update/status").json
+            assert "unit_busy" not in body, state
+        status_file.unlink()
+        body = client.get("/api/update/status").json
+        assert body["state"] == "idle"
+        assert "unit_busy" not in body
+
     def test_oversize_status_file_returns_stale(self, client):
         """litclock-dev#336 — 1MB junk at update.status (above 8KB cap) must be rejected
         by the shared bounded reader and reported as state=stale, NOT a 500

--- a/tests/test_download_images.py
+++ b/tests/test_download_images.py
@@ -1213,8 +1213,8 @@ class TestReleaseSourceDerivation:
         server = _MockServer(release, slug="kapoorankush/litclock-dev")
         server.start()
         try:
-                # slug=None → no env override, so derivation decides.
-                proc = _run(repo, base_url=server.base_url, slug=None)
+            # slug=None → no env override, so derivation decides.
+            proc = _run(repo, base_url=server.base_url, slug=None)
         finally:
             server.stop()
         assert proc.returncode == 0, proc.stderr
@@ -1228,7 +1228,7 @@ class TestReleaseSourceDerivation:
         server = _MockServer(release, slug="kapoorankush/litclock-dev")
         server.start()
         try:
-                proc = _run(repo, base_url=server.base_url, slug=None)
+            proc = _run(repo, base_url=server.base_url, slug=None)
         finally:
             server.stop()
         assert proc.returncode == 0, proc.stderr
@@ -1246,14 +1246,12 @@ class TestReleaseSourceDerivation:
         # skip the corpus guard entirely and prove nothing about the real path
         # (red-team finding).
         digest = _write_corpus(repo, b"00:00|midnight|local corpus\n")
-        release = _make_release(
-            tmp_path, version="v8", bundle_corpus_manifest=True, corpus_hash=digest
-        )
+        release = _make_release(tmp_path, version="v8", bundle_corpus_manifest=True, corpus_hash=digest)
         # Server only knows the DEFAULT slug; the derived somebody/litclock 404s.
         server = _MockServer(release, slug="kapoorankush/litclock")
         server.start()
         try:
-                proc = _run(repo, base_url=server.base_url, slug=None)
+            proc = _run(repo, base_url=server.base_url, slug=None)
         finally:
             server.stop()
         assert proc.returncode == 0, proc.stderr
@@ -1267,7 +1265,7 @@ class TestReleaseSourceDerivation:
         server = _MockServer(release, slug="kapoorankush/litclock")
         server.start()
         try:
-                proc = _run(repo, base_url=server.base_url, slug=None)
+            proc = _run(repo, base_url=server.base_url, slug=None)
         finally:
             server.stop()
         assert proc.returncode == 0, proc.stderr
@@ -1281,9 +1279,9 @@ class TestReleaseSourceDerivation:
         server = _MockServer(release, slug="kapoorankush/litclock")
         server.start()
         try:
-                # Explicit slug points somewhere with no release → graceful no-op,
-                # NOT a silent fallback to the default that does have one.
-                proc = _run(repo, base_url=server.base_url, slug="someone/elsewhere")
+            # Explicit slug points somewhere with no release → graceful no-op,
+            # NOT a silent fallback to the default that does have one.
+            proc = _run(repo, base_url=server.base_url, slug="someone/elsewhere")
         finally:
             server.stop()
         assert proc.returncode == 0, proc.stderr
@@ -1298,13 +1296,11 @@ class TestCorpusImageCorrespondence:
         repo = _make_repo(tmp_path, version="v8")
         _write_corpus(repo, b"00:00|midnight|local corpus\n")
         # Manifest claims a DIFFERENT corpus — exactly the dev-v8/public-v8 case.
-        release = _make_release(
-            tmp_path, version="v8", bundle_corpus_manifest=True, corpus_hash="deadbeef" * 5
-        )
+        release = _make_release(tmp_path, version="v8", bundle_corpus_manifest=True, corpus_hash="deadbeef" * 5)
         server = _MockServer(release)
         server.start()
         try:
-                proc = _run(repo, base_url=server.base_url)
+            proc = _run(repo, base_url=server.base_url)
         finally:
             server.stop()
         assert proc.returncode == 1, f"expected hard failure, got {proc.returncode}"
@@ -1317,13 +1313,11 @@ class TestCorpusImageCorrespondence:
         """The guard must not fire on the correct set — otherwise it's useless."""
         repo = _make_repo(tmp_path, version="v8")
         digest = _write_corpus(repo, b"00:00|midnight|local corpus\n")
-        release = _make_release(
-            tmp_path, version="v8", bundle_corpus_manifest=True, corpus_hash=digest
-        )
+        release = _make_release(tmp_path, version="v8", bundle_corpus_manifest=True, corpus_hash=digest)
         server = _MockServer(release)
         server.start()
         try:
-                proc = _run(repo, base_url=server.base_url)
+            proc = _run(repo, base_url=server.base_url)
         finally:
             server.stop()
         assert proc.returncode == 0, proc.stdout + proc.stderr
@@ -1337,19 +1331,17 @@ class TestCorpusImageCorrespondence:
         server = _MockServer(good)
         server.start()
         try:
-                assert _run(repo, base_url=server.base_url).returncode == 0
+            assert _run(repo, base_url=server.base_url).returncode == 0
         finally:
             server.stop()
         assert (repo / "images" / ".installed-version").read_text().strip() == "v7"
 
         (repo / ".images-version").write_text("v8\n")
-        bad = _make_release(
-            tmp_path, version="v8", bundle_corpus_manifest=True, corpus_hash="cafe" * 10
-        )
+        bad = _make_release(tmp_path, version="v8", bundle_corpus_manifest=True, corpus_hash="cafe" * 10)
         server = _MockServer(bad)
         server.start()
         try:
-                proc = _run(repo, base_url=server.base_url)
+            proc = _run(repo, base_url=server.base_url)
         finally:
             server.stop()
         assert proc.returncode == 1
@@ -1364,7 +1356,7 @@ class TestCorpusImageCorrespondence:
         server = _MockServer(release)
         server.start()
         try:
-                proc = _run(repo, base_url=server.base_url)
+            proc = _run(repo, base_url=server.base_url)
         finally:
             server.stop()
         assert proc.returncode == 0, proc.stdout + proc.stderr
@@ -1373,13 +1365,11 @@ class TestCorpusImageCorrespondence:
     def test_deploy_without_local_csv_still_installs(self, tmp_path):
         """A slim deploy may ship no CSV; the check skips rather than fails."""
         repo = _make_repo(tmp_path, version="v8")  # no image-gen/ at all
-        release = _make_release(
-            tmp_path, version="v8", bundle_corpus_manifest=True, corpus_hash="beef" * 10
-        )
+        release = _make_release(tmp_path, version="v8", bundle_corpus_manifest=True, corpus_hash="beef" * 10)
         server = _MockServer(release)
         server.start()
         try:
-                proc = _run(repo, base_url=server.base_url)
+            proc = _run(repo, base_url=server.base_url)
         finally:
             server.stop()
         assert proc.returncode == 0, proc.stdout + proc.stderr
@@ -1553,6 +1543,43 @@ class TestNonGitHubOriginDoesNotDerive:
         assert any("litclock-dev/releases" in h for h in hits), hits
 
 
+class TestDerivedSlugCharacterAllowlist:
+    """litclock-dev#636 — the derived slug is spliced into api.github.com URLs, so a
+    crafted origin (an attacker or accident editing .git/config) carrying
+    '?', '#', '&', '%', or whitespace could reshape the request path/query.
+    An anchored allowlist (mirroring build-image.yml's ref_ok) rejects those
+    origins into the default-slug fallback instead.
+    """
+
+    _requests_for_origin = staticmethod(TestNonGitHubOriginDoesNotDerive._requests_for_origin)
+
+    def test_hostile_slug_characters_fall_back_to_default(self, tmp_path):
+        hostile_origins = [
+            "https://github.com/kapoorankush/litclock?tab=readme.git",
+            "https://github.com/kapoorankush/litclock#frag.git",
+            "https://github.com/kapoorankush/lit%2fclock.git",
+            "https://github.com/kapoorankush/lit clock.git",
+            "https://github.com/.hidden/litclock.git",
+            "https://github.com/kapoorankush/...git",
+        ]
+        for i, origin in enumerate(hostile_origins):
+            subdir = tmp_path / str(i)
+            subdir.mkdir()
+            hits = self._requests_for_origin(subdir, origin)
+            assert len(hits) == 1, (origin, hits)
+            assert "/kapoorankush/litclock/releases" in hits[0], (origin, hits)
+            slug_part = hits[0].split("/releases")[0].removeprefix("/repos/")
+            for bad in ("?", "#", "%", " ", ".hidden"):
+                assert bad not in slug_part, (origin, bad, hits)
+            assert not slug_part.endswith(("/.", "/..")), (origin, hits)
+
+    def test_dots_and_dashes_in_real_repo_names_still_derive(self, tmp_path):
+        """Allowlist must not over-reject: '.', '_', '-' are legitimate in
+        GitHub owner/repo names."""
+        hits = self._requests_for_origin(tmp_path, "git@github.com:kapoor-ankush/lit.clock_2.git")
+        assert any("/kapoor-ankush/lit.clock_2/releases" in h for h in hits), hits
+
+
 class TestRefusalIsOperatorVisible:
     """litclock-dev#561 red-team — a permanent refusal must raise the '!' glyph.
 
@@ -1569,9 +1596,7 @@ class TestRefusalIsOperatorVisible:
         if origin_url:
             _git_repo_with_origin(repo, origin_url)
         marker = tmp_path / "state" / "update-failed"
-        release = _make_release(
-            tmp_path, version="v8", bundle_corpus_manifest=True, corpus_hash="ab" * 20
-        )
+        release = _make_release(tmp_path, version="v8", bundle_corpus_manifest=True, corpus_hash="ab" * 20)
         server = _MockServer(release)
         server.start()
         try:
@@ -1595,9 +1620,7 @@ class TestRefusalIsOperatorVisible:
     def test_divergent_fork_is_refused_and_flagged(self, tmp_path):
         """A fork whose corpus diverges falls back to the default repo, whose
         images legitimately do NOT match. Refusing is correct; being silent is not."""
-        proc, repo, marker = self._run_mismatch(
-            tmp_path, "https://github.com/somebody/litclock.git"
-        )
+        proc, repo, marker = self._run_mismatch(tmp_path, "https://github.com/somebody/litclock.git")
         assert proc.returncode == 1
         assert marker.exists()
         combined = proc.stdout + proc.stderr
@@ -1608,9 +1631,7 @@ class TestRefusalIsOperatorVisible:
         repo = _make_repo(tmp_path, version="v8")
         _write_corpus(repo, b"00:00|midnight|local corpus\n")
         marker = tmp_path / "state" / "update-failed"
-        release = _make_release(
-            tmp_path, version="v8", bundle_corpus_manifest=True, corpus_hash=""
-        )
+        release = _make_release(tmp_path, version="v8", bundle_corpus_manifest=True, corpus_hash="")
         server = _MockServer(release)
         server.start()
         try:
@@ -1643,9 +1664,7 @@ class TestAlreadyInstalledWrongSource:
         (imgs / "metadata").mkdir(exist_ok=True)
         (imgs / "metadata" / "quote_0000_0_credits.png").write_bytes(b"WRONG credits")
         (imgs / "manifest.json").write_text(
-            json.dumps(
-                {"corpus_hash": installed_corpus_hash, "generator_hash": "0", "files": {}}
-            )
+            json.dumps({"corpus_hash": installed_corpus_hash, "generator_hash": "0", "files": {}})
         )
         _write_byte_manifest(imgs)  # bytes ARE self-consistent
         (imgs / ".installed-version").write_text(f"{version}\n")
@@ -1673,9 +1692,7 @@ class TestAlreadyInstalledWrongSource:
         finally:
             server.stop()
         assert proc.returncode == 0, proc.stdout + proc.stderr
-        assert (imgs / "quote_0000_0.png").read_bytes() == b"RIGHT image", (
-            "wrong-source images were left in place"
-        )
+        assert (imgs / "quote_0000_0.png").read_bytes() == b"RIGHT image", "wrong-source images were left in place"
 
     def test_same_version_matching_corpus_still_short_circuits(self, tmp_path):
         """Guard must not force a 124MB re-download on every correct device."""

--- a/tests/test_reset_setup_sh.py
+++ b/tests/test_reset_setup_sh.py
@@ -133,63 +133,91 @@ class TestGiftMode:
         block = reset_sh_content[idx:elif_idx]
         assert "poweroff" in block
 
-    def test_gift_mode_disables_ssh_before_poweroff(self, reset_sh_content):
-        """#528: gift mode must force SSH off before shipping — an owner who
-        ever enabled SSH (QA, recovery) would otherwise hand the recipient a
-        device with SSH + default creds listening on their network. Every
-        layer: the SOCKET (Bookworm socket-activates sshd — disabling only
-        ssh.service leaves port 22 open, caught by hardware QA 2026-07-16),
-        the classic service, raspi-config posture, and the boot-partition
-        re-enable flags (sshswitch re-enables SSH if a bare `ssh` file
-        exists on /boot or /boot/firmware)."""
+    @staticmethod
+    def _ssh_gate_body(reset_sh_content):
+        """Extract disable_ssh_for_handoff()'s body (litclock-dev#636 moved the
+        #528 gate into a shared function so gift mode and the non-gift
+        factory-reset poweroff enforce the same posture)."""
+        idx = reset_sh_content.find("disable_ssh_for_handoff() {")
+        assert idx != -1, "disable_ssh_for_handoff() definition missing"
+        end = reset_sh_content.find("\n}", idx)
+        assert end != -1
+        return reset_sh_content[idx:end]
+
+    @staticmethod
+    def _gift_block(reset_sh_content):
         # rfind: the end-of-script branch is the LAST $GIFT_MODE test in the
         # file (the first one is the early marker-write block).
         idx = reset_sh_content.rfind('if [[ "$GIFT_MODE" == "true" ]]')
-        elif_idx = reset_sh_content.find("elif", idx)
-        block = reset_sh_content[idx:elif_idx]
+        assert idx != -1, "gift-mode end-of-script branch missing"
+        return reset_sh_content[idx : reset_sh_content.find("elif", idx)]
+
+    def test_ssh_gate_disables_every_layer(self, reset_sh_content):
+        """#528: the handoff gate must force SSH off across every layer: the
+        SOCKET (Bookworm socket-activates sshd — disabling only ssh.service
+        leaves port 22 open, caught by hardware QA 2026-07-16), the classic
+        service, raspi-config posture, and the boot-partition re-enable
+        flags (sshswitch re-enables SSH if a bare `ssh` file exists on
+        /boot or /boot/firmware)."""
+        body = self._ssh_gate_body(reset_sh_content)
         # The socket is the load-bearing unit on current images — a
         # service-only disable ships a device with port 22 still open.
         # Disabled in a SEPARATE call from the service so a missing unit on
         # an older image can't abort the other disable (/review).
-        assert "systemctl disable --now ssh.socket" in block, "must disable ssh.socket separately"
-        assert "systemctl disable --now ssh.service" in block, "must disable ssh.service separately"
-        assert "raspi-config nonint do_ssh 1" in block
-        assert "/boot/firmware/ssh" in block and "/boot/ssh" in block
-        # And it must happen before the poweroff COMMAND (rfind: the word
-        # also appears in comments earlier in the branch).
-        assert block.find("systemctl disable --now ssh") < block.rfind("\n    poweroff")
+        assert "systemctl disable --now ssh.socket" in body, "must disable ssh.socket separately"
+        assert "systemctl disable --now ssh.service" in body, "must disable ssh.service separately"
+        assert "raspi-config nonint do_ssh 1" in body
+        assert "/boot/firmware/ssh" in body and "/boot/ssh" in body
 
-    def test_gift_mode_verifies_port_22_closed_as_gate(self, reset_sh_content):
+    def test_ssh_gate_verifies_port_22_closed(self, reset_sh_content):
         """#528 /review: the SSH-off step is a security gate, not best-effort.
         After disabling, it must verify port 22 is actually closed (the
         disables are all `|| true`, and socket-activation means unit state
-        alone doesn't prove the port is shut) and refuse to power off if
-        sshd still listens — same abort-before-ship posture as the env-wipe
-        failure gate."""
-        idx = reset_sh_content.rfind('if [[ "$GIFT_MODE" == "true" ]]')
-        block = reset_sh_content[idx : reset_sh_content.find("elif", idx)]
-        assert "ss -H -ltn" in block, "must probe listening sockets to verify SSH is off"
+        alone doesn't prove the port is shut) and refuse to power off
+        (exit) if sshd still listens."""
+        body = self._ssh_gate_body(reset_sh_content)
+        assert "ss -H -ltn" in body, "must probe listening sockets to verify SSH is off"
         # Exact port match, not a substring that would false-hit :2222 etc.
-        assert "grep -qx 22" in block
-        # The verify must sit AFTER the disables and gate the poweroff: the
-        # port-open branch exits before the poweroff command.
-        verify_idx = block.find("ss -H -ltn")
-        disable_idx = block.find("systemctl disable --now ssh.socket")
-        exit_idx = block.find("exit 1", verify_idx)
-        poweroff_idx = block.rfind("\n    poweroff")
-        assert disable_idx < verify_idx < exit_idx < poweroff_idx
+        assert "grep -qx 22" in body
+        verify_idx = body.find("ss -H -ltn")
+        disable_idx = body.find("systemctl disable --now ssh.socket")
+        exit_idx = body.find("exit 1", verify_idx)
+        assert disable_idx < verify_idx < exit_idx
 
-    def test_gift_mode_ssh_disable_after_env_wipe_failure_gate(self, reset_sh_content):
-        """#528: on a FAILED gift prep the script exits non-zero and the
-        device stays on — the owner may need SSH to fix it. The SSH disable
-        must therefore sit AFTER the ENV_WIPE_FAILED fatal gate so the
-        failure path never locks the owner out."""
-        idx = reset_sh_content.rfind('if [[ "$GIFT_MODE" == "true" ]]')
-        block = reset_sh_content[idx : reset_sh_content.find("elif", idx)]
+    def test_gift_mode_calls_ssh_gate_before_poweroff(self, reset_sh_content):
+        """#528: gift mode must run the gate, after the ENV_WIPE_FAILED fatal
+        gate (on a FAILED prep the device stays on and the owner may need
+        SSH to fix it) and before the poweroff command."""
+        block = self._gift_block(reset_sh_content)
         gate_idx = block.find('"$ENV_WIPE_FAILED" == "true"')
-        ssh_idx = block.find("systemctl disable --now ssh")
-        assert gate_idx != -1 and ssh_idx != -1
-        assert gate_idx < ssh_idx
+        call_idx = block.find("\n    disable_ssh_for_handoff")
+        poweroff_idx = block.rfind("\n    poweroff")
+        assert gate_idx != -1 and call_idx != -1 and poweroff_idx != -1
+        assert gate_idx < call_idx < poweroff_idx
+
+    def test_poweroff_mode_calls_ssh_gate_before_poweroff(self, reset_sh_content):
+        """litclock-dev#636: the non-gift factory-reset copy invites "move or
+        pass the clock on", so the poweroff path must hand over the same
+        SSH posture a recipient gets from a gift or fresh flash: off. Its
+        env-wipe safety mirrors gift mode structurally — --poweroff implies
+        --strict-env-wipe, whose failure aborts long before this branch."""
+        content = reset_sh_content
+        idx = content.rfind('elif [[ "$DO_POWEROFF" == "true" ]]')
+        assert idx != -1, "poweroff end-of-script branch missing"
+        block = content[idx : content.find("elif", idx + 1)]
+        call_idx = block.find("disable_ssh_for_handoff")
+        poweroff_idx = block.rfind("\n    poweroff")
+        assert call_idx != -1, "poweroff branch must run the SSH handoff gate"
+        assert call_idx < poweroff_idx
+
+    def test_reboot_and_plain_paths_leave_ssh_alone(self, reset_sh_content):
+        """The device stays the owner's on --reboot and the no-flag hint path
+        — no SSH change there (litclock-dev#636 scope: handoff paths only)."""
+        content = reset_sh_content
+        idx = content.rfind('elif [[ "$DO_REBOOT" == "true" ]]')
+        assert idx != -1
+        tail = content[idx:]
+        assert "disable_ssh_for_handoff" not in tail
 
     def test_gift_mode_marker_written_before_shutdown_service_stop(self, reset_sh_content):
         """CRITICAL ordering invariant: the .welcome-mode marker must be written


### PR DESCRIPTION
Port of the litclock-dev#636 review-findings batch (litclock-dev PR #637, requalified and byte-verified), plus the public-only piece of that issue's headline: the factory-reset poweroff now enforces the SSH-off handoff gate.

## Ported fixes

- **Updates tab, dead-updater detection:** `/api/update/status` exposes `unit_busy` on `running` payloads; the poll loop stops after 5 consecutive idle-unit readings (~10s) with honest terminal copy instead of polling a corpse status file forever (the `running` file lies until reboot clears tmpfs, so this is deliberately a stop, not a reload — a reload would loop). The route never issues the verdict itself: one idle sample can be the 2s unit memo lagging the dispatch window, and a false "dead" mid-run would resurrect the litclock-dev#607 stale-card bug. The cold-load probe keeps the truthful server-rendered card rather than trusting a corpse file, promotes into the reading list once the unit is confirmed busy (with a dialog-open guard mirroring the litclock-dev#354 deferral), resets the corpse counter on every fresh running intent (pinned by a red-verified vitest case), and freezes the in-flight phase row when the verdict lands.
- **download_images:** anchored character allowlist on the derived repo slug plus rejection of pure-dot repo segments — a crafted origin URL can no longer reshape the api.github.com request path/query.
- **sudoers 020:** the litclock-dev#510 comment names the reset unit's actual ExecStart.
- **first-boot:** five doubled `|| return || return` deduped.
- **setup_server:** `SSID_FORBIDDEN` gains U+2028/U+2029.

## Public-only: SSH off on the non-gift factory reset

The factory-reset copy invites "move or pass the clock on", but the #528 SSH-off scrub only ran in gift mode — an owner who ever enabled SSH handed over a device with SSH + default creds listening the moment it joined the next network. The #528 gate (socket + service + raspi-config posture + boot-partition flags, then the port-22 `ss` verification) is extracted into `disable_ssh_for_handoff()` and now runs on BOTH handoff paths: gift mode and the poweroff factory reset. The `--reboot` and no-flag paths leave SSH alone — the device stays the owner's.

Safety properties carried over: `--poweroff` implies `--strict-env-wipe`, so a failed config wipe aborts long before the SSH gate and SSH stays available for recovery; if the port-22 verification itself fails (pathological — root-run disables failing), the script refuses to power off, same fail-closed posture gift mode has always had, with the diagnostics in journald. The development repo keeps SSH on (bench access); the divergence is deliberate and documented on litclock-dev#636.

Gates: ruff clean; pytest 3,258 with the freetype-gated tests executed locally (zero relevant skips); vitest 188. Reviewed before opening (Claude adversarial + Codex adversarial; both independently found the corpse-counter leak, fixed in-branch with a regression test verified red without the fix).

Rides the v0.224.0 train.
