### PR TITLE
test+refactor: verify the SSH gate runs, harden dead-updater coverage (post-merge /review)

### DIFF
--- a/scripts/reset-setup.sh
+++ b/scripts/reset-setup.sh
@@ -417,7 +417,7 @@ EOF
     fi
 fi
 
-# #528 + litclock-dev#636: force SSH off before the device leaves the owner's
+# litclock-dev#528 + litclock-dev#636: force SSH off before the device leaves the owner's
 # hands, shared by BOTH handoff paths — gift mode (ships to a recipient) and
 # the non-gift factory-reset poweroff (the PWA copy invites "move or pass the
 # clock on"). The image ships SSH off, but an owner who enabled it (QA,
@@ -452,7 +452,7 @@ disable_ssh_for_handoff() {
     rm -f /boot/ssh /boot/ssh.txt /boot/firmware/ssh /boot/firmware/ssh.txt 2>/dev/null || true
     echo -e "${GREEN}done${NC}"
 
-    # #528 /review: SSH-off is a security GATE, so verify port 22 is
+    # litclock-dev#528 /review: SSH-off is a security GATE, so verify port 22 is
     # actually closed rather than trusting the best-effort disables above
     # (each is `|| true`, and socket-activation means the service state
     # alone doesn't prove the port is shut). If sshd still listens, refuse
@@ -462,9 +462,22 @@ disable_ssh_for_handoff() {
     # can't run we can't verify, so warn and proceed rather than
     # hard-block a handoff on missing tooling.
     if command -v ss >/dev/null 2>&1; then
+        # Capture ss's output AND exit status separately, rather than piping
+        # `ss 2>/dev/null | grep` (litclock-dev#636 /review): a suppressed-stderr
+        # pipe conflates two very different outcomes — "ss ran, port 22 is
+        # closed" (empty output) and "ss itself errored" (also empty output).
+        # A verification gate that reads an ss failure as "verified closed" is
+        # fail-OPEN, the exact posture this gate exists to forbid. Treat an ss
+        # error like an absent ss: warn and proceed (we can't verify), never
+        # silently pass.
+        local ss_out ss_rc
+        ss_out=$(ss -H -ltn 2>/dev/null)
+        ss_rc=$?
+        if [[ "$ss_rc" -ne 0 ]]; then
+            echo -e "${YELLOW}Note: 'ss' failed to run — could not verify port 22 is closed.${NC}"
         # Extract the local port (last colon-field of the Local Address
         # column) and match EXACTLY 22 — avoids false hits on :2222, :220…
-        if ss -H -ltn 2>/dev/null | awk '{n=split($4,a,":"); print a[n]}' | grep -qx 22; then
+        elif printf '%s\n' "$ss_out" | awk '{n=split($4,a,":"); print a[n]}' | grep -qx 22; then
             echo -e "${RED}========================================${NC}"
             echo -e "${RED}  SSH still listening — do NOT hand this device over${NC}"
             echo -e "${RED}========================================${NC}"
@@ -507,7 +520,7 @@ if [[ "$GIFT_MODE" == "true" ]]; then
         echo -e "${YELLOW}  sudo $0 --gift-mode${NC}"
         exit 1
     fi
-    # #528 — shared handoff gate; see disable_ssh_for_handoff above.
+    # litclock-dev#528 — shared handoff gate; see disable_ssh_for_handoff above.
     # Deliberately AFTER the env-wipe-failed gate: on a failed prep the
     # device stays on and the owner may still need SSH to fix it.
     disable_ssh_for_handoff

--- a/src/control_server/static/js/updates.js
+++ b/src/control_server/static/js/updates.js
@@ -223,6 +223,29 @@
     }
   }
 
+  // litclock-dev#636 — claim a fresh, live update run. Both fireApply arms
+  // (202 success and the network-glitch catch) transition into the same
+  // optimistic in-progress state, and BOTH must zero deadUpdaterPolls: a
+  // corpse-evidence count left over from a prior dead-updater verdict would
+  // otherwise false-terminal the new run on its first memo-lag idle sample
+  // (the Codex-P1 class). Kept as one helper so a future run-claiming site
+  // can't silently omit the reset. Invariant (see DEAD_UPDATER_POLL_THRESHOLD
+  // declaration): the counter resets to 0 at EVERY transition that claims a
+  // fresh or resumed live run.
+  function claimOptimisticRun() {
+    // litclock-dev#329 (review C2): arm seenRunning at claim time so the
+    // optimistic-tick branch fires even if the first scheduled poll times
+    // out (e.g. a Phase-7 restart racing the 2s interval).
+    seenRunning = true;
+    deadUpdaterPolls = 0;
+    // litclock-dev#354 codex P2 follow-up — this claim owns the running
+    // state; drop any deferred probe so it can't overwrite the optimistic
+    // phase_index when the modal close listener would otherwise replay it.
+    deferredProbePayload = null;
+    enterReadingList({ state: 'running', phase_index: 1 });
+    schedulePoll();
+  }
+
   function fireApply() {
     if (!form) return;
     var tokenInput = form.querySelector('input[name="token"]');
@@ -238,18 +261,9 @@
       .then(function (response) {
         if (response.ok) {
           // 202 Accepted — kick the reading list. First /api/update/status
-          // poll fires after the standard interval; the server-side
-          // status file is already populated by Phase 1's update_status_set_phase 1.
-          // litclock-dev#329 (review C2): arm seenRunning at user-action time so the
-          // optimistic-tick branch fires even if the very first scheduled
-          // poll times out (e.g. Phase 7 restart racing the 2s interval).
-          seenRunning = true;
-          deadUpdaterPolls = 0;  // litclock-dev#636 — a fresh Apply is a fresh corpse-evidence window
-          // litclock-dev#354 codex P2 follow-up — fireApply owns the new running
-          // state on success; the deferred probe (if any) is now stale.
-          deferredProbePayload = null;
-          enterReadingList({ state: 'running', phase_index: 1 });
-          schedulePoll();
+          // poll fires after the standard interval; the server-side status
+          // file is already populated by Phase 1's update_status_set_phase 1.
+          claimOptimisticRun();
           return;
         }
         // litclock-dev#354 codex P2 follow-up — non-OK (typically 409 concurrent
@@ -293,19 +307,11 @@
       .catch(function () {
         // Network glitch (rare on LAN). Try once more by entering the
         // reading-list optimistically; if no update is actually running,
-        // the first poll will report state=idle and we exit cleanly.
-        // litclock-dev#329 (review C2): arm seenRunning here too — the user clicked
-        // Apply, so we're in a "running" intent for the duration regardless
-        // of whether the POST round-tripped cleanly.
-        seenRunning = true;
-        deadUpdaterPolls = 0;  // litclock-dev#636 — same: new run, stale corpse count must not carry
-        // litclock-dev#354 codex P2 follow-up — optimistic enterReadingList here
-        // claims the running state; drop any deferred probe so it can't
-        // overwrite the optimistic phase_index when the close listener
-        // would otherwise have replayed.
-        deferredProbePayload = null;
-        enterReadingList({ state: 'running', phase_index: 1 });
-        schedulePoll();
+        // the first poll will report state=idle and we exit cleanly. Same
+        // claim as the success arm — the user clicked Apply, so we're in a
+        // "running" intent for the duration regardless of whether the POST
+        // round-tripped cleanly.
+        claimOptimisticRun();
       });
   }
 
@@ -398,6 +404,14 @@
   // consecutive ones — at the 2s poll interval the threshold spans ~10s,
   // comfortably past any memo/activation gap. The verdict is deliberately
   // NOT a reload: the dead file persists, so a reload would loop.
+  //
+  // INVARIANT: deadUpdaterPolls resets to 0 at every transition that
+  // re-establishes the polling relationship — claimOptimisticRun() (both
+  // fireApply arms), a healthy running poll (unit_busy!==false in
+  // handleStatusPayload), and any reconnect resume (which re-establishes it
+  // regardless of the resumed status's liveness). A site that omits the
+  // reset inherits up to THRESHOLD-1 stale corpse ticks and can false-verdict
+  // the run on its first memo-lag sample.
   var DEAD_UPDATER_POLL_THRESHOLD = 5;
   var deadUpdaterPolls = 0;
 
@@ -702,8 +716,20 @@
             // may never come.
             reconnectArmed = false;
             consecutivePollFailures = 0;
-            deadUpdaterPolls = 0;  // litclock-dev#636 — resuming a live run is fresh evidence
-            enterReadingList(statusBody);
+            // litclock-dev#636 — resume re-establishes the polling relationship,
+            // so the corpse count from before the disconnect is stale
+            // evidence: reset it unconditionally (a pre-disconnect count of 4
+            // plus one post-resume idle sample must not sum to a false
+            // verdict). But a `running` status after a reconnect can still be
+            // a corpse file that outlived the Phase-7 restart, so only ENTER
+            // the live reading list on unit_busy!==false — a unit_busy===false
+            // resume hands back to the poll loop, which re-accumulates from
+            // zero and stops on the corpse via the quiet cold-verdict path
+            // instead of showing a live view for it.
+            deadUpdaterPolls = 0;
+            if (statusBody.unit_busy !== false) {
+              enterReadingList(statusBody);
+            }
             schedulePoll();
             return;
           }

--- a/tests/js/updates.dead-updater.test.js
+++ b/tests/js/updates.dead-updater.test.js
@@ -149,6 +149,18 @@ describe("updates.js litclock-dev#636 dead-updater detection", () => {
     expect(terminalEl().textContent).toMatch(/stopped before finishing/i);
     expect(terminalEl().textContent).toMatch(/previous version/i);
 
+    // The in-flight phase row must be frozen FAILED, not left spinning: a
+    // spinner animating above "the updater is no longer running" is the
+    // exact contradiction the verdict's updateRowStates(..., true) fixes.
+    expect(
+      document.querySelector('.phase-row[data-phase-index="4"]').getAttribute("data-state"),
+      "the active phase must freeze failed under the verdict copy"
+    ).toBe("failed");
+    expect(
+      document.querySelector('.phase-row[data-phase-index="1"]').getAttribute("data-state"),
+      "earlier phases stay completed"
+    ).toBe("completed");
+
     // Polling stopped — and no reload was issued (the dead file persists;
     // a reload would loop). jsdom throws on navigation, so reaching this
     // point without an error is itself the no-reload proof; pin the
@@ -280,5 +292,112 @@ describe("updates.js litclock-dev#636 dead-updater detection", () => {
     await vi.advanceTimersByTimeAsync(10000);
     await flushMicrotasks();
     expect(statusCalls(mock), "polling stops on the confirmed corpse").toBe(settled);
+  });
+
+  it("rule 5b: the fireApply network-error catch path also resets the corpse counter", async () => {
+    // The second reset site (fireApply's .catch → optimistic reading list on
+    // a failed POST). A corpse-era count carried into that optimistic run
+    // would false-terminal it on the first memo-lag sample, same as rule 5's
+    // success-path scenario.
+    buildDom();
+    mock.register(/\/api\/update\/check$/, { status: 200, body: { ok: true, available: true } });
+    // The apply POST rejects (network glitch) → catch path claims the run.
+    // A throwing function (not Promise.reject at registration time, which
+    // would reject before anything awaits it) — the mock turns the throw
+    // into a rejected fetch, exercising fireApply's real .catch branch.
+    mock.register(/\/api\/update\/apply$/, () => {
+      throw new TypeError("network glitch");
+    });
+    let phase2 = false;
+    mock.register(/\/api\/update\/status$/, () => {
+      const body = phase2 ? running(2, true) : running(1, false);
+      return { ok: true, status: 200, json: async () => body, text: async () => JSON.stringify(body) };
+    });
+
+    loadScript("updates.js");
+    await flushMicrotasks();
+    for (let k = 0; k < 7; k++) {
+      await vi.advanceTimersByTimeAsync(2000);
+      await flushMicrotasks();
+    }
+    const settled = statusCalls(mock);
+    await vi.advanceTimersByTimeAsync(4000);
+    await flushMicrotasks();
+    expect(statusCalls(mock), "corpse confirmed, polling stopped").toBe(settled);
+
+    // Apply → POST rejects → catch → claimOptimisticRun resets the counter.
+    phase2 = true;
+    const form = document.querySelector("form[data-confirm-action='update_apply']");
+    form.dispatchEvent(new Event("submit", { cancelable: true }));
+    document.querySelector("[data-modal-confirm]").click();
+    await flushMicrotasks();
+    expect(readingListEl().hidden, "catch path enters the optimistic reading list").toBe(false);
+    // The counter is fresh, so the run advances normally, no false verdict.
+    await vi.advanceTimersByTimeAsync(4000);
+    await flushMicrotasks();
+    expect(terminalEl().hidden, "fresh optimistic run must not false-verdict").toBe(true);
+  });
+
+  it("rule 6: the dialog-open guard defers promotion, then promotes after the sheet closes", async () => {
+    // updates.js:!(dialog && dialog.open) — yanking the card into the reading
+    // list under an open confirm sheet is the litclock-dev#354 race the guard
+    // mirrors. Rule 4 only covers promotion with the sheet closed.
+    buildDom();
+    mock.register(/\/api\/update\/check$/, { status: 200, body: { ok: true, available: true } });
+    mock.register(/\/api\/update\/apply$/, { status: 202, body: { ok: true } });
+    // Probe sees a corpse candidate (card kept); every later poll is
+    // confirmed-busy, which would normally promote.
+    mock.register(/\/api\/update\/status$/, sequencedStatus([running(1, false), running(2, true)]));
+
+    loadScript("updates.js");
+    await flushMicrotasks();
+    expect(readingListEl().hidden, "probe keeps the card").toBe(true);
+
+    // Open the confirm sheet, THEN let a confirmed-busy poll land.
+    const form = document.querySelector("form[data-confirm-action='update_apply']");
+    form.dispatchEvent(new Event("submit", { cancelable: true }));
+    const dialog = document.querySelector("dialog.confirm-sheet[data-action='update_apply']");
+    expect(dialog.open).toBe(true);
+    await vi.advanceTimersByTimeAsync(2000);
+    await flushMicrotasks();
+    expect(readingListEl().hidden, "must NOT yank the card under an open sheet").toBe(true);
+
+    // Cancel the sheet; the next poll promotes.
+    document.querySelector("[data-modal-cancel]").click();
+    await vi.advanceTimersByTimeAsync(2000);
+    await flushMicrotasks();
+    expect(readingListEl().hidden, "promotes once the sheet is closed").toBe(false);
+  });
+
+  it("rule 7: a reconnect resume resets the corpse counter (a pre-disconnect count can't false-verdict)", async () => {
+    // updates.js reconnect-resume: the count from before the Phase-7 restart
+    // is stale evidence. Accumulate 4 idle readings, drop into reconnect via
+    // poll failures, resume on a live status, then one more idle sample —
+    // without the reset that lone sample would be the 5th and false-verdict.
+    buildDom({ inProgress: true, phase: 3 });
+    mock.register(/\/api\/update\/check$/, { status: 200, body: { ok: true, available: true } });
+    mock.register(/\/api\/health$/, { status: 200, body: { version: "0.223.0" } }); // same version → status consult
+    let n = 0;
+    mock.register(/\/api\/update\/status$/, () => {
+      n++;
+      // 1: cold-load probe (idle, harmless). 2-5: four idle readings in the
+      // list (count → 4). 6-8: three network failures → reconnect. 9: the
+      // pollHealth status consult — a LIVE resume (unit_busy:true). 10+: idle.
+      if (n >= 6 && n <= 8) throw new TypeError("restart window");
+      const body = n === 9 ? running(3, true) : running(3, false);
+      return { ok: true, status: 200, json: async () => body, text: async () => JSON.stringify(body) };
+    });
+
+    loadScript("updates.js");
+    await flushMicrotasks();
+    // Drive: 4 idle (count→4), 3 failures (reconnect), health+resume, then idle.
+    for (let i = 0; i < 9; i++) {
+      await vi.advanceTimersByTimeAsync(2000);
+      await flushMicrotasks();
+    }
+    // Resume reset the counter; a handful of post-resume idle samples must
+    // not have summed with the pre-disconnect 4 to reach the threshold.
+    expect(terminalEl().hidden, "pre-disconnect count must not carry across a resume").toBe(true);
+    expect(readingListEl().hidden, "the live resume shows the reading list").toBe(false);
   });
 });

--- a/tests/test_control_server.py
+++ b/tests/test_control_server.py
@@ -1291,12 +1291,25 @@ class TestUpdatesJsSeenRunningArmed:
         assert depth == 0, f"unbalanced braces while scanning {name}"
         return src[match.end() : i - 1]
 
-    def test_seen_running_armed_in_fire_apply(self) -> None:
+    def test_seen_running_armed_via_fire_apply_claim(self) -> None:
+        # litclock-dev#636 refactor: both fireApply arms now claim the run
+        # through claimOptimisticRun(), which is where seenRunning is armed.
+        # Guard both halves — fireApply must call the claim, and the claim
+        # must arm the flag — so a refactor dropping either still fails.
         src = self.UPDATES_JS.read_text()
-        body = self._extract_function_body(src, "fireApply")
-        assert "seenRunning = true" in body, (
-            "fireApply() must arm seenRunning at user-action time so the optimistic "
-            "Phase-7 tick still fires when the first scheduled poll times out (#329 review C2)"
+        fire_body = self._extract_function_body(src, "fireApply")
+        assert "claimOptimisticRun()" in fire_body, (
+            "fireApply() must claim the run via claimOptimisticRun() so seenRunning "
+            "is armed at user-action time (litclock-dev#329 review C2)"
+        )
+        claim_body = self._extract_function_body(src, "claimOptimisticRun")
+        assert "seenRunning = true" in claim_body, (
+            "claimOptimisticRun() must arm seenRunning so the optimistic Phase-7 tick "
+            "still fires when the first scheduled poll times out (litclock-dev#329 review C2)"
+        )
+        assert "deadUpdaterPolls = 0" in claim_body, (
+            "claimOptimisticRun() must zero the dead-updater counter so a prior "
+            "corpse verdict can't false-terminal the new run (litclock-dev#636)"
         )
 
     def test_seen_running_armed_in_handle_status_payload(self) -> None:

--- a/tests/test_control_server_updates_routes.py
+++ b/tests/test_control_server_updates_routes.py
@@ -690,6 +690,19 @@ class TestApiUpdateStatus:
         assert body["state"] == "idle"
         assert "unit_busy" not in body
 
+    def test_stale_state_carries_no_unit_busy_key(self, client):
+        """litclock-dev#636 — the unit_busy field is scoped to `running`; a torn
+        or oversize file (state=stale) must not carry it either, even when the
+        unit is busy. The JS stale branch just re-polls; a stray unit_busy
+        there would be meaningless."""
+        status_file = Path(os.environ.get("LITCLOCK_UPDATE_STATUS_FILE"))
+        status_file.parent.mkdir(parents=True, exist_ok=True)
+        status_file.write_text("{ corrupt")
+        with patch("control_server.routes.updates.update_state.update_is_busy", return_value=True):
+            body = client.get("/api/update/status").json
+        assert body["state"] == "stale"
+        assert "unit_busy" not in body
+
     def test_oversize_status_file_returns_stale(self, client):
         """litclock-dev#336 — 1MB junk at update.status (above 8KB cap) must be rejected
         by the shared bounded reader and reported as state=stale, NOT a 500

--- a/tests/test_download_images.py
+++ b/tests/test_download_images.py
@@ -1557,10 +1557,12 @@ class TestDerivedSlugCharacterAllowlist:
         hostile_origins = [
             "https://github.com/kapoorankush/litclock?tab=readme.git",
             "https://github.com/kapoorankush/litclock#frag.git",
+            "https://github.com/kapoorankush/lit&clock.git",
             "https://github.com/kapoorankush/lit%2fclock.git",
             "https://github.com/kapoorankush/lit clock.git",
             "https://github.com/.hidden/litclock.git",
-            "https://github.com/kapoorankush/...git",
+            "https://github.com/kapoorankush/...git",  # '..' repo segment
+            "https://github.com/kapoorankush/..git",  # bare '.' repo segment
         ]
         for i, origin in enumerate(hostile_origins):
             subdir = tmp_path / str(i)
@@ -1569,7 +1571,7 @@ class TestDerivedSlugCharacterAllowlist:
             assert len(hits) == 1, (origin, hits)
             assert "/kapoorankush/litclock/releases" in hits[0], (origin, hits)
             slug_part = hits[0].split("/releases")[0].removeprefix("/repos/")
-            for bad in ("?", "#", "%", " ", ".hidden"):
+            for bad in ("?", "#", "&", "%", " ", ".hidden"):
                 assert bad not in slug_part, (origin, bad, hits)
             assert not slug_part.endswith(("/.", "/..")), (origin, hits)
 

--- a/tests/test_reset_setup_sh.py
+++ b/tests/test_reset_setup_sh.py
@@ -136,7 +136,7 @@ class TestGiftMode:
     @staticmethod
     def _ssh_gate_body(reset_sh_content):
         """Extract disable_ssh_for_handoff()'s body (litclock-dev#636 moved the
-        #528 gate into a shared function so gift mode and the non-gift
+        litclock-dev#528 gate into a shared function so gift mode and the non-gift
         factory-reset poweroff enforce the same posture)."""
         idx = reset_sh_content.find("disable_ssh_for_handoff() {")
         assert idx != -1, "disable_ssh_for_handoff() definition missing"
@@ -153,7 +153,7 @@ class TestGiftMode:
         return reset_sh_content[idx : reset_sh_content.find("elif", idx)]
 
     def test_ssh_gate_disables_every_layer(self, reset_sh_content):
-        """#528: the handoff gate must force SSH off across every layer: the
+        """litclock-dev#528: the handoff gate must force SSH off across every layer: the
         SOCKET (Bookworm socket-activates sshd — disabling only ssh.service
         leaves port 22 open, caught by hardware QA 2026-07-16), the classic
         service, raspi-config posture, and the boot-partition re-enable
@@ -170,7 +170,7 @@ class TestGiftMode:
         assert "/boot/firmware/ssh" in body and "/boot/ssh" in body
 
     def test_ssh_gate_verifies_port_22_closed(self, reset_sh_content):
-        """#528 /review: the SSH-off step is a security gate, not best-effort.
+        """litclock-dev#528 /review: the SSH-off step is a security gate, not best-effort.
         After disabling, it must verify port 22 is actually closed (the
         disables are all `|| true`, and socket-activation means unit state
         alone doesn't prove the port is shut) and refuse to power off
@@ -185,7 +185,7 @@ class TestGiftMode:
         assert disable_idx < verify_idx < exit_idx
 
     def test_gift_mode_calls_ssh_gate_before_poweroff(self, reset_sh_content):
-        """#528: gift mode must run the gate, after the ENV_WIPE_FAILED fatal
+        """litclock-dev#528: gift mode must run the gate, after the ENV_WIPE_FAILED fatal
         gate (on a FAILED prep the device stays on and the owner may need
         SSH to fix it) and before the poweroff command."""
         block = self._gift_block(reset_sh_content)
@@ -205,7 +205,11 @@ class TestGiftMode:
         idx = content.rfind('elif [[ "$DO_POWEROFF" == "true" ]]')
         assert idx != -1, "poweroff end-of-script branch missing"
         block = content[idx : content.find("elif", idx + 1)]
-        call_idx = block.find("disable_ssh_for_handoff")
+        # Anchor on the CALL (line-leading), not a bare substring: a later
+        # comment mentioning the function, or the call being commented out,
+        # must not keep this test green with the gate gone (matches the
+        # gift-mode test's anchoring).
+        call_idx = block.find("\n    disable_ssh_for_handoff")
         poweroff_idx = block.rfind("\n    poweroff")
         assert call_idx != -1, "poweroff branch must run the SSH handoff gate"
         assert call_idx < poweroff_idx
@@ -218,6 +222,78 @@ class TestGiftMode:
         assert idx != -1
         tail = content[idx:]
         assert "disable_ssh_for_handoff" not in tail
+
+    # --- Behavioral gate tests (litclock-dev#636 /review) ------------------
+    # The structural tests above prove the gate is WIRED; these RUN it. A
+    # security gate that is only pattern-matched is unverified: the whole
+    # point is that port-22-still-open aborts the poweroff, and that only the
+    # exact port 22 (not :2222) triggers it, and that an ss that can't verify
+    # never silently passes. Extract the function and execute it under bash
+    # with systemctl/raspi-config/rm and a scripted `ss` stubbed on PATH.
+
+    @staticmethod
+    def _run_ssh_gate(tmp_path, ss_script):
+        """Execute disable_ssh_for_handoff() with a stubbed environment.
+
+        ss_script is the body of a fake `ss` on PATH. Returns the completed
+        process (rc 0 = gate passed/proceeded, rc 1 = gate aborted).
+        """
+        import subprocess
+
+        content = RESET_SH.read_text()
+        start = content.find("disable_ssh_for_handoff() {")
+        # Match the function's closing brace on its own line — a bare find("}")
+        # would truncate at the first ${VAR:-default} or awk block.
+        end = content.find("\n}", start)
+        assert start != -1 and end != -1, "could not extract disable_ssh_for_handoff()"
+        func = content[start : end + 2]
+
+        stubs = tmp_path / "bin"
+        stubs.mkdir()
+        for name in ("systemctl", "raspi-config", "rm"):
+            (stubs / name).write_text("#!/bin/sh\nexit 0\n")
+        (stubs / "ss").write_text("#!/bin/sh\n" + ss_script)
+        for f in stubs.iterdir():
+            f.chmod(0o755)
+
+        # `local` is only valid inside a function, so the extracted body must
+        # run as a function call, not top-level. Colors are referenced inside.
+        harness = f"RED=''; GREEN=''; YELLOW=''; NC=''\n{func}\ndisable_ssh_for_handoff\n"
+        return subprocess.run(
+            ["bash", "-c", harness],
+            capture_output=True,
+            text=True,
+            env={"PATH": f"{stubs}:/usr/bin:/bin"},
+            timeout=10,
+        )
+
+    def test_gate_aborts_when_port_22_still_listening(self, tmp_path):
+        """The load-bearing promise: sshd still on :22 → exit 1 (poweroff
+        never reached)."""
+        proc = self._run_ssh_gate(tmp_path, 'echo "LISTEN 0 128 0.0.0.0:22 0.0.0.0:*"\n')
+        assert proc.returncode == 1, proc.stderr
+        assert "still listening" in proc.stdout.lower() or "still listening" in proc.stderr.lower()
+
+    def test_gate_proceeds_when_only_high_ports_listen(self, tmp_path):
+        """grep -qx 22 must not false-hit :2222 / :220 — a device with only
+        those open must pass the gate (rc 0)."""
+        ss = 'echo "LISTEN 0 128 0.0.0.0:2222 0.0.0.0:*"\necho "LISTEN 0 128 0.0.0.0:220 0.0.0.0:*"\n'
+        proc = self._run_ssh_gate(tmp_path, ss)
+        assert proc.returncode == 0, proc.stdout + proc.stderr
+
+    def test_gate_proceeds_when_no_ports_listen(self, tmp_path):
+        """Port 22 verified closed → gate passes."""
+        proc = self._run_ssh_gate(tmp_path, "exit 0\n")  # no output = nothing listening
+        assert proc.returncode == 0, proc.stdout + proc.stderr
+
+    def test_gate_does_not_fail_open_when_ss_errors(self, tmp_path):
+        """litclock-dev#636 /review: an `ss` that ERRORS (nonzero, no output)
+        must NOT read as 'verified closed'. It warns and proceeds (can't
+        verify), exactly like an absent ss — never a silent pass that a
+        pipe-to-grep would have produced."""
+        proc = self._run_ssh_gate(tmp_path, "exit 3\n")  # ss present but fails
+        assert proc.returncode == 0, proc.stdout + proc.stderr
+        assert "could not verify" in proc.stdout.lower() or "could not verify" in proc.stderr.lower()
 
     def test_gift_mode_marker_written_before_shutdown_service_stop(self, reset_sh_content):
         """CRITICAL ordering invariant: the .welcome-mode marker must be written

--- a/tests/test_wifi_retry_flow.py
+++ b/tests/test_wifi_retry_flow.py
@@ -1854,7 +1854,23 @@ class TestManualSsidReviewHardening(_ManualSsidHarness):
         Storage=persistent and is collected into support bundles, and the
         same string reaches the e-ink connecting splash. `.strip()` only
         trims the ends, so it is no defence."""
-        for bad in ("Home\nFORGED: authentication failure", "Home\r\nx", "Home\x00x", "Home\x1b[2Jx"):
+        # litclock-dev#636 — U+2028/U+2029 (line/paragraph separators) and the
+        # C1 controls (\x80-\x9f, e.g. \x85 NEL) are rejected too: str.splitlines
+        # and some terminals treat them as line breaks, so the same
+        # journal-forge / splash-injection reach applies. They are unprintable
+        # by isprintable() but sit outside the C0 range, so SSID_FORBIDDEN
+        # names them explicitly — pin that here so a regression narrowing the
+        # set back to C0/C1-only ranges ships red.
+        bad_ssids = (
+            "Home\nFORGED: authentication failure",
+            "Home\r\nx",
+            "Home\x00x",
+            "Home\x1b[2Jx",
+            "Home\u2028x",  # LINE SEPARATOR
+            "Home\u2029x",  # PARAGRAPH SEPARATOR
+            "Home\x85x",  # C1 NEL
+        )
+        for bad in bad_ssids:
             calls = []
             response = self._post(
                 monkeypatch,


### PR DESCRIPTION
Follow-up from running the FULL /review pipeline on the merged #636 port (#52) — the critical pass plus testing, maintainability, security, and performance specialists, Codex structured review, and adversarial passes. The batch had merged on two adversarial passes; the whole pipeline should have run first. It did now, and the code came back sound, but the specialists surfaced real gaps.

## The headline: the SSH gate was never executed

The factory-reset SSH-off gate (`disable_ssh_for_handoff`) had only structural tests — string matches over the script text. A security gate that is only pattern-matched is unverified: a refactor could satisfy every grep and still not block. Added behavioral tests that extract the function and RUN it under bash with stubbed `systemctl`/`raspi-config`/`ss`:

- port 22 still listening → the gate exits 1, poweroff never reached;
- only `:2222`/`:220` listening → proceeds (pins that `grep -qx 22` is an exact match, not a substring);
- nothing listening → proceeds.

And a **fail-open fix** the security specialist caught: the old `ss -H -ltn 2>/dev/null | ... | grep` conflated "ss ran, port closed" (empty output) with "ss itself errored" (also empty output), so an `ss` that failed at runtime read as "verified closed". It now captures `ss`'s output and exit status separately and, on an `ss` error, warns and proceeds exactly like an absent `ss` — never a silent pass. A test drives an erroring `ss` and asserts the warning fires.

## Dead-updater refactor + refinement

- Both fireApply arms claim the run through one `claimOptimisticRun()` helper (was duplicated), with the `deadUpdaterPolls` reset invariant stated at the threshold declaration.
- The reconnect-resume path resets the corpse counter unconditionally (a pre-disconnect count is stale evidence) but only enters the live reading list on `unit_busy!==false` — a corpse status that outlived the Phase-7 restart hands back to the poll loop instead of showing a live view for it.

## Test gaps closed (each verified red without its guard)

- JS: dialog-open promotion guard, verdict row-freeze, reconnect reset, fireApply catch-path reset.
- Route: a stale status file carries no `unit_busy` key even when busy.
- download_images: `&` and a bare `.` repo segment added to the slug hostile vectors.
- wifi: SSID rejection pins U+2028/U+2029 and the C1 NEL.

## Hygiene

The 7 bare `#528` references (a dev-repo issue; public tops out at #46) are now `litclock-dev#528`, matching the convention every other dev ref uses here. 5 predated this work; my SSH refactor added 2.

Gates: ruff clean; pytest 3,263 with the freetype-gated tests executed locally (zero relevant skips); vitest 191. No fleet-reaching behavior change beyond the `ss` fail-open hardening and the reconnect-resume refinement, both correctness improvements to paths that only run during an update or a factory reset. Rides the v0.224.0 train.
